### PR TITLE
Clarify DSPy is opt-in, not mandatory (#13)

### DIFF
--- a/DSPY_CLARIFICATION.md
+++ b/DSPY_CLARIFICATION.md
@@ -1,0 +1,1 @@
+> **Note:** DSPy is **opt-in** (useDspy defaults false), Layer 3 of defense chain (after L1 regex + L2 length heuristic). Findings are always WARN-level, never BLOCK. Pipeline operates normally when unavailable.


### PR DESCRIPTION
Added DSPY_CLARIFICATION.md documenting that DSPy is an opt-in intelligence layer (Layer 3), not a mandatory engine.

Key points:
- useDspy defaults to false
- Layer 3 runs after L1 regex + L2 length heuristic
- Findings are always WARN-level, never BLOCK
- Pipeline operates normally when DSPy is unavailable

Closes #13