### PR TITLE
test(dspy): E2E fallback chain + document silent-degradation bug — resolves #14

### DIFF
--- a/tests/helpers/dspy-stub.js
+++ b/tests/helpers/dspy-stub.js
@@ -15,6 +15,8 @@
  *   - tests/hollow-artifact-dspy-fallback.test.js (issue #14)
  *   - tests/memory-dspy-gate.test.js (issue #14 scope update)
  *   - tests/cli-dry-run-dspy.test.js (issue #15) — indirectly via closed port
+ *
+ * Executor: Devin-AI
  */
 
 import http from "node:http";

--- a/tests/helpers/dspy-stub.js
+++ b/tests/helpers/dspy-stub.js
@@ -54,20 +54,30 @@ export function createDspyStub(options = {}) {
         } catch {
           requests.push({ url: req.url, method: req.method, body });
         }
-        if (mode === "timeout") {
-          // Never respond — client AbortController must fire.
-          return;
+        switch (mode) {
+          case "timeout":
+            // Never respond — client AbortController must fire.
+            return;
+          case "500":
+            res.writeHead(500, { "Content-Type": "text/plain" });
+            return res.end("internal server error");
+          case "malformed":
+            res.writeHead(200, { "Content-Type": "application/json" });
+            return res.end("not valid json{");
+          case "score":
+            res.writeHead(status, { "Content-Type": "application/json" });
+            return res.end(JSON.stringify({ score, feedback }));
+          default:
+            // DEFENSIVE GUARD: unknown mode — fail loudly so test authors
+            // catch typos immediately. Without this, unknown modes would
+            // silently fall through to the healthy-score response, producing
+            // false-passing tests (the stub responds 200 + score 0.8 even
+            // though the test author intended a failure scenario).
+            res.writeHead(500, { "Content-Type": "text/plain" });
+            return res.end(
+              `dspy-stub: unrecognised mode "${mode}". Valid: score | 500 | timeout | malformed`,
+            );
         }
-        if (mode === "500") {
-          res.writeHead(500, { "Content-Type": "text/plain" });
-          return res.end("internal server error");
-        }
-        if (mode === "malformed") {
-          res.writeHead(200, { "Content-Type": "application/json" });
-          return res.end("not valid json{");
-        }
-        res.writeHead(status, { "Content-Type": "application/json" });
-        return res.end(JSON.stringify({ score, feedback }));
       });
       req.on("error", () => {});
     });
@@ -98,6 +108,16 @@ export function createDspyStub(options = {}) {
  * Grab a port that is guaranteed to be closed (server shut down).
  * Callers use this for "DSPy unreachable" scenarios — any connection
  * attempt yields ECONNREFUSED.
+ *
+ * NOTE: technically there is a TOCTOU window between this function
+ * returning the port and the test issuing a connect() to it — another
+ * process on the same machine could theoretically bind the same
+ * ephemeral port in that gap. In practice on CI runners and dev
+ * machines this never happens because (a) the kernel does not hand
+ * the same ephemeral port out twice in rapid succession, and (b) the
+ * tests run within milliseconds of receiving the port. If you ever
+ * see a flake here, switch to the inline `port = 1` pattern used in
+ * tests/cli-dry-run-dspy.test.js.
  *
  * @returns {Promise<{ port: number, endpoint: string }>}
  */

--- a/tests/helpers/dspy-stub.js
+++ b/tests/helpers/dspy-stub.js
@@ -1,0 +1,112 @@
+/**
+ * DSPy HTTP stub helper for adversarial fallback tests.
+ *
+ * Instead of mocking `fetch`, tests use a real local HTTP server so the
+ * `callDspy()` code path is exercised end-to-end — matching how DSPy
+ * behaves in production (network, AbortController, JSON parse, timeouts).
+ *
+ * Modes:
+ *   - "score"     : respond 200 with { score, feedback }
+ *   - "500"       : respond 500 (server error)
+ *   - "timeout"   : accept connection but never respond (client must abort)
+ *   - "malformed" : respond 200 but body is not valid JSON
+ *
+ * Used by:
+ *   - tests/hollow-artifact-dspy-fallback.test.js (issue #14)
+ *   - tests/memory-dspy-gate.test.js (issue #14 scope update)
+ *   - tests/cli-dry-run-dspy.test.js (issue #15) — indirectly via closed port
+ */
+
+import http from "node:http";
+
+/**
+ * Spin up a local DSPy stub server on an ephemeral port.
+ *
+ * @param {object} options
+ * @param {"score"|"500"|"timeout"|"malformed"} [options.mode="score"]
+ * @param {number} [options.score=0.8]
+ * @param {string} [options.feedback="ok"]
+ * @param {number} [options.status=200]
+ * @returns {Promise<{ port: number, endpoint: string, requests: Array<object>, close: () => Promise<void> }>}
+ */
+export function createDspyStub(options = {}) {
+  const {
+    mode = "score",
+    score = 0.8,
+    feedback = "ok",
+    status = 200,
+  } = options;
+  const requests = [];
+  // Track sockets so timeout-mode tests can force-close pending connections
+  // during afterEach. server.close() alone hangs on never-responded requests.
+  const sockets = new Set();
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      let body = "";
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        try {
+          requests.push({ url: req.url, method: req.method, body: JSON.parse(body || "null") });
+        } catch {
+          requests.push({ url: req.url, method: req.method, body });
+        }
+        if (mode === "timeout") {
+          // Never respond — client AbortController must fire.
+          return;
+        }
+        if (mode === "500") {
+          res.writeHead(500, { "Content-Type": "text/plain" });
+          return res.end("internal server error");
+        }
+        if (mode === "malformed") {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          return res.end("not valid json{");
+        }
+        res.writeHead(status, { "Content-Type": "application/json" });
+        return res.end(JSON.stringify({ score, feedback }));
+      });
+      req.on("error", () => {});
+    });
+    server.on("connection", (socket) => {
+      sockets.add(socket);
+      socket.on("close", () => sockets.delete(socket));
+    });
+    server.on("clientError", () => {});
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      resolve({
+        port,
+        endpoint: `http://127.0.0.1:${port}/evaluate`,
+        requests,
+        close: () =>
+          new Promise((r) => {
+            for (const socket of sockets) socket.destroy();
+            sockets.clear();
+            server.closeAllConnections?.();
+            server.close(() => r());
+          }),
+      });
+    });
+  });
+}
+
+/**
+ * Grab a port that is guaranteed to be closed (server shut down).
+ * Callers use this for "DSPy unreachable" scenarios — any connection
+ * attempt yields ECONNREFUSED.
+ *
+ * @returns {Promise<{ port: number, endpoint: string }>}
+ */
+export function getClosedPort() {
+  return new Promise((resolve) => {
+    const server = http.createServer();
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      server.close(() => {
+        resolve({ port, endpoint: `http://127.0.0.1:${port}/evaluate` });
+      });
+    });
+  });
+}

--- a/tests/hollow-artifact-dspy-fallback.test.js
+++ b/tests/hollow-artifact-dspy-fallback.test.js
@@ -169,7 +169,7 @@ describe("DSPy fallback — Scenario 2: endpoint returns HTTP 500", () => {
     assert.equal(observed.dspy["doc.md"], null, "500 ⇒ null entry");
     assert.ok(stub.requests.length > 0, "stub server must have been contacted at least once");
     assert.ok(
-      warnCapture.some((line) => /500/.test(line)),
+      warnCapture.some((line) => /DSPy service returned 500/.test(line)),
       "callDspy should emit a WARN about the 500 status",
     );
   });
@@ -238,6 +238,14 @@ describe("DSPy fallback — Scenario 4: server-side hang triggers AbortControlle
     const elapsed = Date.now() - startedAt;
 
     assert.equal(result, null, "timeout must surface as null (graceful degradation)");
+    // Lower bound: AbortController must actually have waited the full timeout.
+    // Without this, a future regression that bails out before issuing fetch()
+    // (e.g. callDspy returning null instantly) would still pass the upper-bound
+    // check, silently breaking the timeout contract.
+    assert.ok(
+      elapsed >= timeoutMs - 50,
+      `callDspy returned in ${elapsed}ms but timeoutMs is ${timeoutMs}; AbortController likely did not gate the request`,
+    );
     assert.ok(
       elapsed < timeoutMs + 1500,
       `callDspy elapsed ${elapsed}ms; expected < ${timeoutMs + 1500}ms (timeoutMs + buffer)`,

--- a/tests/hollow-artifact-dspy-fallback.test.js
+++ b/tests/hollow-artifact-dspy-fallback.test.js
@@ -246,13 +246,49 @@ describe("DSPy fallback — Scenario 4: server-side hang triggers AbortControlle
       elapsed >= timeoutMs - 50,
       `callDspy returned in ${elapsed}ms but timeoutMs is ${timeoutMs}; AbortController likely did not gate the request`,
     );
+    // Upper bound: keep tight (+500ms) so a real regression — e.g. the
+    // AbortController stops working and the call hangs until Node's test
+    // runner kills the process — surfaces as a failed assertion, not as a
+    // long-running test. Bump only if a specific CI runner needs more
+    // headroom (document the runner in the comment).
     assert.ok(
-      elapsed < timeoutMs + 1500,
-      `callDspy elapsed ${elapsed}ms; expected < ${timeoutMs + 1500}ms (timeoutMs + buffer)`,
+      elapsed < timeoutMs + 500,
+      `callDspy elapsed ${elapsed}ms; expected < ${timeoutMs + 500}ms (timeoutMs + buffer)`,
     );
     assert.ok(
       warnCapture.some((line) => /DSPy evaluation failed/.test(line)),
       "callDspy should emit a WARN about the abort/timeout",
+    );
+  });
+});
+
+describe("DSPy fallback — Scenario 5: server returns malformed JSON", () => {
+  let stub;
+
+  beforeEach(async () => {
+    stub = await createDspyStub({ mode: "malformed" });
+  });
+
+  afterEach(async () => {
+    await stub.close();
+  });
+
+  // AC: malformed JSON body ⇒ response.json() throws ⇒ callDspy's outer
+  // try/catch treats it as a graceful failure and returns null. This proves
+  // the dspy-client.ts try/catch (lines 65-101) actually covers JSON parse
+  // errors, not just network errors.
+  it("returns null and emits a WARN when the server responds with invalid JSON", async () => {
+    const result = await callDspy(
+      { type: "artifact", id: "doc.md", content: SUBSTANTIVE },
+      stub.endpoint,
+      1000,
+    );
+
+    assert.equal(result, null, "malformed JSON must surface as null");
+    assert.ok(stub.requests.length === 1, "stub server must have been contacted exactly once");
+    assert.ok(
+      warnCapture.some((line) => /DSPy evaluation failed/.test(line)),
+      "callDspy should emit a WARN about the JSON parse error",
     );
   });
 });

--- a/tests/hollow-artifact-dspy-fallback.test.js
+++ b/tests/hollow-artifact-dspy-fallback.test.js
@@ -1,0 +1,250 @@
+/**
+ * E2E adversarial tests for the DSPy fallback chain — Issue #14.
+ *
+ * Scope: prove that the L1 (regex) → L2 (length) → L3 (DSPy) pipeline
+ * degrades gracefully when DSPy is unreachable, slow, or returns
+ * adversarial scores. Real local HTTP stub server (tests/helpers/dspy-stub.js)
+ * exercises src/core/dspy-client.ts callDspy() end-to-end — no fetch mocks,
+ * no http mocks.
+ *
+ * Architectural contracts under test:
+ *   1. WARN-NOT-BLOCK — DSPy findings never block (severity = WARN)
+ *   2. GRACEFUL DEGRADATION — failure ⇒ null, never throws
+ *   3. L1+L2 INTEGRITY — deterministic checks remain authoritative
+ *      regardless of DSPy availability
+ *
+ * Spec source: GitHub issue #14 acceptance criteria + maintainer plan
+ *   approval comment.
+ *
+ * Mock audit: real fs (os.tmpdir), real HTTP via createDspyStub, real engine.
+ *   console.warn silenced per-test to keep stdout clean while still letting
+ *   tests inspect emitted warnings via a captured array when needed.
+ *
+ * Executor: Devin-AI
+ */
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+import { DefendEngine } from "../dist/core/engine.js";
+import { hollowArtifactGuard } from "../dist/guards/hollow-artifact.js";
+import { callDspy } from "../dist/core/dspy-client.js";
+import { Severity } from "../dist/core/types.js";
+
+import { createDspyStub, getClosedPort } from "./helpers/dspy-stub.js";
+
+// Substantive content that passes the L2 minimum-length check by itself.
+// Reused across scenarios so we can isolate which layer triggers a finding.
+const SUBSTANTIVE =
+  "This document contains a real paragraph of meaningful content that is well above the default minimum length threshold so that length-based findings do not interfere with the layer we are exercising right now.";
+
+let tmp;
+let savedWarn;
+let warnCapture;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "did-dspy-fallback-"));
+  warnCapture = [];
+  savedWarn = console.warn;
+  console.warn = (...args) => {
+    warnCapture.push(args.map((a) => String(a)).join(" "));
+  };
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+  console.warn = savedWarn;
+});
+
+function write(rel, content) {
+  fs.writeFileSync(path.join(tmp, rel), content);
+}
+
+function makeConfig(hollowOverrides = {}) {
+  return {
+    version: "1.0",
+    guards: {
+      hollowArtifact: {
+        enabled: true,
+        useDspy: true,
+        dspyTimeoutMs: 1000,
+        extensions: [".md"],
+        ...hollowOverrides,
+      },
+    },
+  };
+}
+
+describe("DSPy fallback — Scenario 1: endpoint unreachable", () => {
+  // AC: DSPy unreachable + useDspy=true ⇒ L1 still BLOCKs hollow artifacts.
+  // The deterministic regex layer must be authoritative even when the
+  // semantic layer cannot be reached.
+  it("L1 BLOCK still fires on a TODO-only file when DSPy is unreachable", async () => {
+    const { endpoint } = await getClosedPort();
+    write("hollow.md", "# Title\n\nTODO: write the rest of this doc.\n");
+
+    const engine = new DefendEngine(
+      tmp,
+      makeConfig({ dspyEndpoint: endpoint }),
+    );
+    engine.use(hollowArtifactGuard);
+
+    const verdict = await engine.run(["hollow.md"]);
+
+    assert.equal(verdict.passed, false, "L1 must BLOCK on TODO regardless of DSPy state");
+    const blocking = verdict.results
+      .flatMap((r) => r.findings)
+      .filter((f) => f.severity === Severity.BLOCK);
+    assert.ok(
+      blocking.some((f) => f.filePath === "hollow.md"),
+      "expected a BLOCK finding for hollow.md",
+    );
+  });
+
+  it("DSPy unreachable degrades to null in semanticEvals (no throw)", async () => {
+    const { endpoint } = await getClosedPort();
+    write("doc.md", `${SUBSTANTIVE}\n`);
+
+    let observed;
+    const engine = new DefendEngine(
+      tmp,
+      makeConfig({ dspyEndpoint: endpoint }),
+    );
+    engine.use({
+      id: "observer",
+      name: "observer",
+      description: "captures ctx.semanticEvals",
+      check: async (ctx) => {
+        observed = ctx.semanticEvals;
+        return { guardId: "observer", passed: true, findings: [], durationMs: 0 };
+      },
+    });
+
+    await engine.run(["doc.md"]);
+
+    assert.ok(observed?.dspy, "engine must populate semanticEvals.dspy even on failure");
+    assert.equal(observed.dspy["doc.md"], null, "unreachable DSPy ⇒ null entry");
+  });
+});
+
+describe("DSPy fallback — Scenario 2: endpoint returns HTTP 500", () => {
+  let stub;
+
+  beforeEach(async () => {
+    stub = await createDspyStub({ mode: "500" });
+  });
+
+  afterEach(async () => {
+    await stub.close();
+  });
+
+  // AC: DSPy 500 ⇒ pipeline continues, no crash, no BLOCK-from-DSPy.
+  // callDspy emits a console.warn but returns null; engine records null.
+  it("pipeline completes and stores null for the file when DSPy returns 500", async () => {
+    write("doc.md", `${SUBSTANTIVE}\n`);
+
+    let observed;
+    const engine = new DefendEngine(
+      tmp,
+      makeConfig({ dspyEndpoint: stub.endpoint }),
+    );
+    engine.use({
+      id: "observer",
+      name: "observer",
+      description: "captures ctx.semanticEvals",
+      check: async (ctx) => {
+        observed = ctx.semanticEvals;
+        return { guardId: "observer", passed: true, findings: [], durationMs: 0 };
+      },
+    });
+    engine.use(hollowArtifactGuard);
+
+    const verdict = await engine.run(["doc.md"]);
+
+    assert.equal(verdict.passed, true, "no BLOCK should arise from DSPy 500");
+    assert.ok(observed?.dspy, "semanticEvals.dspy must be populated");
+    assert.equal(observed.dspy["doc.md"], null, "500 ⇒ null entry");
+    assert.ok(stub.requests.length > 0, "stub server must have been contacted at least once");
+    assert.ok(
+      warnCapture.some((line) => /500/.test(line)),
+      "callDspy should emit a WARN about the 500 status",
+    );
+  });
+});
+
+describe("DSPy fallback — Scenario 3: low semantic score", () => {
+  let stub;
+
+  beforeEach(async () => {
+    stub = await createDspyStub({ mode: "score", score: 0.0, feedback: "very generic" });
+  });
+
+  afterEach(async () => {
+    await stub.close();
+  });
+
+  // AC: score=0.0 ⇒ WARN finding, never BLOCK. WARN-NOT-BLOCK is the
+  // architectural contract for any DSPy-derived finding.
+  it("substantive doc with score 0.0 produces a WARN, never BLOCK", async () => {
+    write("doc.md", `${SUBSTANTIVE}\n`);
+
+    const engine = new DefendEngine(
+      tmp,
+      makeConfig({ dspyEndpoint: stub.endpoint }),
+    );
+    engine.use(hollowArtifactGuard);
+
+    const verdict = await engine.run(["doc.md"]);
+
+    const findings = verdict.results.flatMap((r) => r.findings);
+    const warns = findings.filter((f) => f.severity === Severity.WARN);
+    const blocks = findings.filter((f) => f.severity === Severity.BLOCK);
+
+    assert.equal(blocks.length, 0, "DSPy must never produce a BLOCK finding");
+    assert.ok(
+      warns.some((f) => f.filePath === "doc.md" && /DSPy/.test(f.message)),
+      "expected a DSPy WARN for doc.md with score 0.0",
+    );
+    assert.equal(verdict.passed, true, "WARN-only ⇒ pipeline still passes");
+  });
+});
+
+describe("DSPy fallback — Scenario 4: server-side hang triggers AbortController", () => {
+  let stub;
+
+  beforeEach(async () => {
+    stub = await createDspyStub({ mode: "timeout" });
+  });
+
+  afterEach(async () => {
+    await stub.close();
+  });
+
+  // AC: timeout ⇒ callDspy returns null within timeoutMs + buffer.
+  // We assert directly against callDspy here so the timing assertion is not
+  // diluted by engine bookkeeping. The buffer accounts for AbortController
+  // teardown and event-loop scheduling on slow CI.
+  it("returns null within timeoutMs + buffer when the server never responds", async () => {
+    const timeoutMs = 200;
+    const startedAt = Date.now();
+    const result = await callDspy(
+      { type: "artifact", id: "doc.md", content: SUBSTANTIVE },
+      stub.endpoint,
+      timeoutMs,
+    );
+    const elapsed = Date.now() - startedAt;
+
+    assert.equal(result, null, "timeout must surface as null (graceful degradation)");
+    assert.ok(
+      elapsed < timeoutMs + 1500,
+      `callDspy elapsed ${elapsed}ms; expected < ${timeoutMs + 1500}ms (timeoutMs + buffer)`,
+    );
+    assert.ok(
+      warnCapture.some((line) => /DSPy evaluation failed/.test(line)),
+      "callDspy should emit a WARN about the abort/timeout",
+    );
+  });
+});

--- a/tests/memory-dspy-gate.test.js
+++ b/tests/memory-dspy-gate.test.js
@@ -1,0 +1,201 @@
+/**
+ * E2E tests for the lesson quality gate's DSPy fallback — Issue #14 scope update.
+ *
+ * Scope: prove that recordLesson() with `dspy.enabled = true` behaves
+ * correctly across four DSPy states: down (unreachable), down (HTTP 500),
+ * low score (gate rejects), high score (happy path).
+ *
+ * Critical bug DOCUMENTED here (NOT fixed):
+ *   When DSPy is enabled but the call fails (network down OR 500 response),
+ *   recordLesson silently persists the lesson without emitting any WARN to
+ *   the user. The user has no way of knowing the quality gate was bypassed.
+ *
+ *   This is the "silent degradation" bug noted in maintainer-comment #14.
+ *   Tests in scenarios 1 and 2 assert the CURRENT (buggy) behavior so a
+ *   future refactor cannot accidentally re-introduce it without conscious
+ *   review. PR B (separate) will fix the bug and flip the assertions.
+ *
+ * Real local HTTP stub server (tests/helpers/dspy-stub.js) exercises
+ * src/core/memory.ts → callDspy() end-to-end — no fetch mocks.
+ *
+ * Executor: Devin-AI
+ */
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+import { recordLesson } from "../dist/core/memory.js";
+import { EvidenceLevel } from "../dist/core/types.js";
+
+import { createDspyStub, getClosedPort } from "./helpers/dspy-stub.js";
+
+const BASE_LESSON = {
+  title: "Always cite source files when describing behavior",
+  scenario:
+    "An agent claimed a function returned an ISO-8601 timestamp but did not link to the source file or test output that proved it.",
+  wrongApproach:
+    "Asserting return-value shapes from inferred behavior without running or reading the code.",
+  correctApproach:
+    "Open the source, run the test, paste the actual output, and tag the claim [RUNTIME].",
+  insight:
+    "Agents must distinguish [INFER] from [RUNTIME]; users cannot trust untagged claims.",
+  category: "process",
+  evidence: EvidenceLevel.RUNTIME,
+  confidence: 0.9,
+};
+
+let tmp;
+let savedWarn;
+let warnCapture;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "did-memory-gate-"));
+  warnCapture = [];
+  savedWarn = console.warn;
+  console.warn = (...args) => {
+    warnCapture.push(args.map((a) => String(a)).join(" "));
+  };
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+  console.warn = savedWarn;
+});
+
+function readPersistedCount() {
+  const p = path.join(tmp, "lessons.jsonl");
+  if (!fs.existsSync(p)) return 0;
+  return fs
+    .readFileSync(p, "utf-8")
+    .split("\n")
+    .filter((line) => line.trim().length > 0).length;
+}
+
+describe("recordLesson + DSPy quality gate — Scenario 1: DSPy unreachable", () => {
+  // BUG: quality gate silently passes when DSPy is down (no WARN emitted).
+  // This test documents current behavior. Fix tracked in PR B (separate issue).
+  // DO NOT change this assertion without also fixing memory.ts and adding the WARN.
+  it("persists the lesson with qualityScore=null and emits NO user-facing WARN", async () => {
+    const { endpoint } = await getClosedPort();
+
+    const result = await recordLesson(BASE_LESSON, tmp, {
+      enabled: true,
+      endpoint,
+      timeoutMs: 500,
+    });
+
+    assert.equal(result.persisted, true, "lesson is persisted despite gate being unreachable");
+    assert.equal(result.qualityScore, null, "qualityScore must be null (not 0)");
+    assert.equal(result.qualityFeedback, null, "qualityFeedback must be null when DSPy is down");
+    assert.equal(readPersistedCount(), 1, "lessons.jsonl must contain the persisted lesson");
+
+    // BUG ASSERTION (PR A): the only warning emitted is the dspy-client's
+    // internal "DSPy evaluation failed" log. There is NO WARN that tells
+    // the user "Lesson persisted WITHOUT quality check" — the silent-
+    // degradation bug. PR B will introduce that WARN and this assertion
+    // will flip from "no quality-gate warning" to "quality-gate WARN present".
+    const qualityGateWarn = warnCapture.find((line) =>
+      /quality.?gate/i.test(line) && /persisted WITHOUT/i.test(line),
+    );
+    assert.equal(
+      qualityGateWarn,
+      undefined,
+      "BUG: no quality-gate-bypass WARN is emitted today; PR B will add it",
+    );
+  });
+});
+
+describe("recordLesson + DSPy quality gate — Scenario 2: DSPy returns HTTP 500", () => {
+  let stub;
+
+  beforeEach(async () => {
+    stub = await createDspyStub({ mode: "500" });
+  });
+
+  afterEach(async () => {
+    await stub.close();
+  });
+
+  // BUG: quality gate silently passes when DSPy is down (no WARN emitted).
+  // This test documents current behavior. Fix tracked in PR B (separate issue).
+  // DO NOT change this assertion without also fixing memory.ts and adding the WARN.
+  it("persists the lesson with qualityScore=null and emits NO user-facing WARN", async () => {
+    const result = await recordLesson(BASE_LESSON, tmp, {
+      enabled: true,
+      endpoint: stub.endpoint,
+      timeoutMs: 500,
+    });
+
+    assert.equal(result.persisted, true, "lesson is persisted despite gate returning 500");
+    assert.equal(result.qualityScore, null, "qualityScore must be null on 500");
+    assert.equal(readPersistedCount(), 1, "lessons.jsonl must contain the persisted lesson");
+    assert.ok(stub.requests.length >= 1, "stub server must have been contacted");
+
+    const qualityGateWarn = warnCapture.find((line) =>
+      /quality.?gate/i.test(line) && /persisted WITHOUT/i.test(line),
+    );
+    assert.equal(
+      qualityGateWarn,
+      undefined,
+      "BUG: no quality-gate-bypass WARN is emitted today; PR B will add it",
+    );
+  });
+});
+
+describe("recordLesson + DSPy quality gate — Scenario 3: low semantic score", () => {
+  let stub;
+
+  beforeEach(async () => {
+    stub = await createDspyStub({ mode: "score", score: 0.2, feedback: "too generic" });
+  });
+
+  afterEach(async () => {
+    await stub.close();
+  });
+
+  // Sanity check: when DSPy IS reachable and returns a low score, the gate
+  // does its job. This is the contrast scenario that proves the gate works
+  // when the network is healthy — making the silent-degradation bug above
+  // significant by comparison.
+  it("rejects the lesson (persisted=false) when DSPy returns score < 0.5", async () => {
+    const result = await recordLesson(BASE_LESSON, tmp, {
+      enabled: true,
+      endpoint: stub.endpoint,
+      timeoutMs: 500,
+    });
+
+    assert.equal(result.persisted, false, "gate must reject low-quality lesson");
+    assert.equal(result.qualityScore, 0.2, "qualityScore must reflect DSPy verdict");
+    assert.equal(result.qualityFeedback, "too generic", "feedback must propagate");
+    assert.equal(readPersistedCount(), 0, "rejected lesson must not be persisted");
+  });
+});
+
+describe("recordLesson + DSPy quality gate — Scenario 4: high semantic score", () => {
+  let stub;
+
+  beforeEach(async () => {
+    stub = await createDspyStub({ mode: "score", score: 0.85, feedback: "actionable + specific" });
+  });
+
+  afterEach(async () => {
+    await stub.close();
+  });
+
+  // Happy path: DSPy reachable + high score ⇒ persisted with feedback.
+  it("persists the lesson with the DSPy score+feedback when score >= 0.5", async () => {
+    const result = await recordLesson(BASE_LESSON, tmp, {
+      enabled: true,
+      endpoint: stub.endpoint,
+      timeoutMs: 500,
+    });
+
+    assert.equal(result.persisted, true, "happy path persists");
+    assert.equal(result.qualityScore, 0.85, "qualityScore must propagate");
+    assert.equal(result.qualityFeedback, "actionable + specific", "feedback must propagate");
+    assert.equal(readPersistedCount(), 1, "lessons.jsonl must contain the persisted lesson");
+  });
+});


### PR DESCRIPTION
## Description

PR A of the two-PR plan approved on issue #14. Tests-only — zero production code change.

Adds end-to-end coverage for the DSPy fallback chain (L1 regex → L2 length → L3 DSPy) using a real local HTTP stub server, no `fetch` / `http` / `fs` mocks. The stub exercises `src/core/dspy-client.ts` `callDspy()` end-to-end so the test contract reflects how DSPy behaves in production (network, AbortController, JSON parse, timeouts).

A second file (`tests/memory-dspy-gate.test.js`) covers the `recordLesson(--quality-gate)` path. Two of its scenarios document — but do not fix — the **silent-degradation bug** the maintainer flagged in #14: when DSPy is unreachable or returns 500, the lesson is persisted with `qualityScore=null` and **no user-facing WARN is emitted**. The bug fix is tracked separately in PR B.

Fixes #14

## Type of Change

- [x] 📝 Documentation only — *no, this is tests; box is "tests-only behavior"*
- [x] 🐛 Bug documentation (no behavior change in `src/`)

(No `src/` files were modified in this PR.)

## What changes

| File | Purpose |
|---|---|
| `tests/helpers/dspy-stub.js` | Local HTTP stub server. Modes: `score` / `500` / `timeout` / `malformed`. Tracks live sockets so timeout-mode tests can force-close pending connections during `afterEach`. |
| `tests/hollow-artifact-dspy-fallback.test.js` | 4 fallback scenarios driven through `DefendEngine` + `hollowArtifactGuard`. |
| `tests/memory-dspy-gate.test.js` | 4 quality-gate scenarios driven through `recordLesson()`. Scenarios 1+2 carry an explicit DO-NOT-CHANGE comment marking the silent-degradation bug. |

## Acceptance Criteria — issue #14

| AC | Where |
|---|---|
| Unreachable + `useDspy=true` → L1 BLOCK still fires | `hollow-artifact-dspy-fallback.test.js` Scenario 1 |
| HTTP 500 → pipeline continues, WARN logged, no crash | Scenario 2 |
| Score 0.0 → WARN, never BLOCK (WARN-NOT-BLOCK contract) | Scenario 3 |
| Timeout → `callDspy()` returns `null` within `timeoutMs + buffer` | Scenario 4 |
| Real `os.tmpdir()` fixtures, no `fs` mocks | All scenarios |
| `tests/hollow-artifact-dspy-fallback.test.js` exists | ✅ |
| `tests/memory-dspy-gate.test.js` exists (scope update) | ✅ |
| Silent-degradation bug documented for PR B | Scenarios 1+2 of `memory-dspy-gate.test.js` |
| Inline comments instead of new fixture file | Per maintainer Q1 answer |

## Open Questions resolved (per maintainer comment)

- **Q1** Fixture location → inline comments in test files. ✅
- **Q2** `eval <file>` banner test scope → defer to PR B. ✅ (no `eval.ts` test in this PR)
- **Q3** Lesson án lệ → reserve for PR B. ✅ (no `lessons.jsonl` edit in this PR)

## Checklist

- [x] My code follows the [consistency rules](.agents/rules/rule-consistency.md)
- [x] I used conventional commit format for the PR title
- [x] I added tests for new functionality
- [x] All existing tests pass (`npm test`)
- [x] I updated documentation (README, CHANGELOG) if needed — *N/A, tests-only*
- [x] No `any` types used
- [x] No new external dependencies added

## Evidence

```
$ npm run lint
> defense-in-depth@0.6.0 lint
> tsc --noEmit
(exit 0)

$ npm test
…
ℹ tests 286
ℹ pass 286
ℹ fail 0
ℹ duration_ms 12524
```

286 = 277 baseline (post #6–#12 merge) + 9 new (4 fallback-chain + 4 quality-gate + 1 second L1-still-BLOCKs assertion). All scenarios use real HTTP via `createDspyStub()` or a guaranteed-closed port via `getClosedPort()`.

## Follow-up — PR B (separate)

PR B will fix the silent-degradation bug in `src/core/memory.ts` (emit a quality-gate-bypass WARN), add a banner to `src/cli/eval.ts`, flip the `memory-dspy-gate.test.js` Scenarios 1+2 assertions from "WARN absent" to "WARN present", and record the first án lệ that goes from red to green.

Executor: Devin-AI


Link to Devin session: https://app.devin.ai/sessions/1e8caa3cff7c42a7937fb2fce832fcfe
Requested by: @tamld
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tamld/defense-in-depth/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
