### PR TITLE
feat(cli): add --dry-run-dspy flag to simulate DSPy failure — resolves #15

### DIFF
--- a/docs/dev-guide/dspy-providers.md
+++ b/docs/dev-guide/dspy-providers.md
@@ -406,6 +406,38 @@ be blocked by an unavailable AI service.
 
 ---
 
+## Testing your fallback (`--dry-run-dspy`)
+
+Before pushing a config change that enables `useDspy: true`, simulate the
+"DSPy offline" path locally so you can confirm your L1+L2 governance still
+passes without DSPy:
+
+```bash
+npx defense-in-depth verify --dry-run-dspy
+```
+
+The flag force-disables DSPy semantic enrichment for the current run only —
+no config file changes, no environment variables. A banner is written to
+**stderr** so it is easy to filter in CI logs:
+
+```
+⚠  --dry-run-dspy: DSPy semantic evaluation skipped
+```
+
+Recommended use cases:
+
+- **Pre-deploy check**: verify your repo passes verification when the DSPy
+  endpoint is unavailable (network outage, provider quota exceeded, etc.).
+- **CI smoke test**: run `verify --dry-run-dspy` as a separate job to prove
+  the deterministic governance layer is still authoritative.
+- **Debugging false WARNs**: isolate whether a finding came from DSPy
+  (disappears with `--dry-run-dspy`) or from the deterministic guards.
+
+The flag only affects the `verify` command. `eval <file>` still requires
+DSPy because semantic evaluation is its primary purpose.
+
+---
+
 ## See Also
 
 - [`docs/dev-guide/writing-guards.md`](writing-guards.md) — Guard authoring guide

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -87,13 +87,21 @@ Commands:
   eval      Evaluate artifact quality with DSPy semantic analysis (v0.5, opt-in)
 
 Options:
-  --help    Show this help
-  --version Show version
+  --help            Show this help
+  --version         Show version
+
+Verify-only options:
+  --files <paths>   Verify the listed files instead of staged files
+  --hook <name>     Internal: invoked by Git hooks (pre-commit / pre-push)
+  --dry-run-dspy    Force-disable DSPy semantic evaluation for this run.
+                    Useful for verifying L1+L2 governance still passes when
+                    your DSPy endpoint is offline. Banner is written to stderr.
 
 Examples:
   npx defense-in-depth init
   npx defense-in-depth verify
   npx defense-in-depth verify --files src/app.ts docs/plan.md
+  npx defense-in-depth verify --dry-run-dspy
   npx defense-in-depth doctor
 
 Learn more: https://github.com/tamld/defense-in-depth

--- a/src/cli/verify.ts
+++ b/src/cli/verify.ts
@@ -4,15 +4,18 @@
  * Runs all enabled guards against staged files or specified paths.
  *
  * Usage:
- *   defense-in-depth verify                    # scan staged files
- *   defense-in-depth verify --files a.md b.ts  # scan specific files
- *   defense-in-depth verify --hook pre-commit   # called from hook
+ *   defense-in-depth verify                       # scan staged files
+ *   defense-in-depth verify --files a.md b.ts     # scan specific files
+ *   defense-in-depth verify --hook pre-commit     # called from hook
+ *   defense-in-depth verify --dry-run-dspy        # simulate DSPy unavailable
  */
 
 import { execSync } from "node:child_process";
 import { DefendEngine } from "../core/engine.js";
+import { loadConfig } from "../core/config-loader.js";
 import { allBuiltinGuards } from "../guards/index.js";
 import { Severity } from "../core/types.js";
+import type { DefendConfig } from "../core/types.js";
 
 export async function verify(
   projectRoot: string,
@@ -20,13 +23,15 @@ export async function verify(
 ): Promise<void> {
   const hookMode = args.includes("--hook");
   const hook = hookMode ? args[args.indexOf("--hook") + 1] : undefined;
+  const dryRunDspy = args.includes("--dry-run-dspy");
 
   // Get files to check
   let files: string[];
   const filesIdx = args.indexOf("--files");
 
   if (filesIdx !== -1) {
-    // Explicit file list
+    // Explicit file list — terminate at the next flag (so `--dry-run-dspy`
+    // appearing after `--files a.md` does not get treated as a path).
     files = args.slice(filesIdx + 1).filter((a) => !a.startsWith("--"));
   } else {
     // Default: staged files from Git
@@ -39,8 +44,22 @@ export async function verify(
     return;
   }
 
+  // --dry-run-dspy: load config and force-disable DSPy semantic enrichment so
+  // users can verify their L1+L2 governance still passes when DSPy is offline.
+  // Banner goes to stderr (predictable for CI output and shell redirection).
+  let config: DefendConfig | undefined;
+  if (dryRunDspy) {
+    config = loadConfig(projectRoot);
+    if (config.guards.hollowArtifact) {
+      config.guards.hollowArtifact.useDspy = false;
+    }
+    process.stderr.write(
+      "⚠  --dry-run-dspy: DSPy semantic evaluation skipped\n",
+    );
+  }
+
   // Build engine with all guards
-  const engine = new DefendEngine(projectRoot);
+  const engine = new DefendEngine(projectRoot, config);
   engine.useAll(allBuiltinGuards);
 
   // Get optional context

--- a/tests/cli-dry-run-dspy.test.js
+++ b/tests/cli-dry-run-dspy.test.js
@@ -1,0 +1,250 @@
+/**
+ * Subprocess integration tests for `verify --dry-run-dspy` — Issue #15.
+ *
+ * Spec: GitHub issue #15 acceptance criteria + maintainer plan approval.
+ *
+ * What this catches that in-process tests cannot:
+ *   - argv parsing (`--dry-run-dspy` actually recognised)
+ *   - banner is written to stderr (not stdout)
+ *   - process.stderr.write semantics (no Node-version timestamp prefix)
+ *   - verdict + exit code match the no-flag run (deterministic guards
+ *     remain authoritative)
+ *   - flag combines correctly with --files
+ *   - no DSPy HTTP call is attempted when the flag is set
+ *
+ * The "no network call" assertion is the central anti-hallucination test:
+ * we point the config at a guaranteed-unreachable port and assert that NO
+ * "ECONNREFUSED" or "DSPy evaluation failed" warning surfaces — proving
+ * callDspy() was never invoked.
+ *
+ * Mock audit: real fs (os.tmpdir), real subprocess (spawnSync), no network.
+ *
+ * Executor: Devin-AI
+ */
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, "..");
+const CLI_PATH = path.join(REPO_ROOT, "dist", "cli", "index.js");
+
+// Port 1 is reserved/never bound on any common OS, so any attempted connection
+// surfaces immediately as ECONNREFUSED. We use this as a "DSPy is unreachable"
+// canary: if the process tried to reach DSPy, callDspy() would log
+// "DSPy evaluation failed for artifact:<file>: ... ECONNREFUSED ..." to
+// stderr. With --dry-run-dspy that warning must NOT appear.
+const CLOSED_PORT_ENDPOINT = "http://127.0.0.1:1/evaluate";
+
+const SUBSTANTIVE =
+  "This document contains a real paragraph of meaningful content that is well above the default minimum length threshold so the length-based finding does not interfere with the case under test.";
+
+let tmp;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "did-cli-dry-run-dspy-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function runCli(args, cwd = tmp) {
+  return spawnSync(process.execPath, [CLI_PATH, ...args], {
+    cwd,
+    encoding: "utf-8",
+    env: { ...process.env, NO_COLOR: "1" },
+  });
+}
+
+function write(rel, content) {
+  const full = path.join(tmp, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+/**
+ * Config that points DSPy at the closed port AND enables useDspy. Without
+ * the flag, the verify run will try to call this endpoint and surface an
+ * ECONNREFUSED warning. With the flag, no call is made → no warning.
+ */
+const DSPY_ENABLED_CLOSED_PORT_CONFIG = [
+  "version: '1.0'",
+  "guards:",
+  "  hollowArtifact:",
+  "    enabled: true",
+  "    useDspy: true",
+  `    dspyEndpoint: '${CLOSED_PORT_ENDPOINT}'`,
+  "    dspyTimeoutMs: 500",
+  "    extensions: ['.md']",
+  "    patterns:",
+  "      - 'TODO'",
+  "      - 'TBD'",
+  "      - 'PLACEHOLDER'",
+  "",
+].join("\n");
+
+describe("verify --dry-run-dspy — banner output", () => {
+  it("writes the banner to stderr (not stdout)", () => {
+    write("defense.config.yml", DSPY_ENABLED_CLOSED_PORT_CONFIG);
+    write("docs/clean.md", SUBSTANTIVE);
+
+    const r = runCli(["verify", "--dry-run-dspy", "--files", "docs/clean.md"]);
+
+    assert.match(
+      r.stderr,
+      /--dry-run-dspy: DSPy semantic evaluation skipped/,
+      `expected banner on stderr; got stderr=${JSON.stringify(r.stderr)}`,
+    );
+    assert.doesNotMatch(
+      r.stdout,
+      /--dry-run-dspy/,
+      "banner must NOT appear on stdout",
+    );
+  });
+
+  it("no banner is emitted without the flag", () => {
+    // Use defaults (useDspy disabled) so no network call happens; we only
+    // care that the banner string is absent from both streams.
+    write("defense.config.yml", "version: '1.0'\nguards:\n  hollowArtifact:\n    enabled: true\n    patterns: ['TODO']\n");
+    write("docs/clean.md", SUBSTANTIVE);
+
+    const r = runCli(["verify", "--files", "docs/clean.md"]);
+
+    assert.doesNotMatch(r.stderr, /--dry-run-dspy/);
+    assert.doesNotMatch(r.stdout, /--dry-run-dspy/);
+  });
+});
+
+describe("verify --dry-run-dspy — no DSPy network call", () => {
+  // Anti-hallucination assertion: with useDspy=true + an unreachable endpoint,
+  // a normal verify run would log "DSPy evaluation failed ... ECONNREFUSED".
+  // With --dry-run-dspy that log MUST NOT appear, proving callDspy() was
+  // never invoked.
+  it("substantive doc: ECONNREFUSED warning is absent when flag is set", () => {
+    write("defense.config.yml", DSPY_ENABLED_CLOSED_PORT_CONFIG);
+    write("docs/clean.md", SUBSTANTIVE);
+
+    const r = runCli(["verify", "--dry-run-dspy", "--files", "docs/clean.md"]);
+
+    const combined = `${r.stdout}\n${r.stderr}`;
+    assert.doesNotMatch(
+      combined,
+      /ECONNREFUSED/,
+      "no DSPy connection should be attempted when flag is set",
+    );
+    assert.doesNotMatch(
+      combined,
+      /DSPy evaluation failed/,
+      "callDspy() must not be invoked when flag is set",
+    );
+  });
+
+  it("control: without the flag, the same config DOES surface a DSPy failure", () => {
+    write("defense.config.yml", DSPY_ENABLED_CLOSED_PORT_CONFIG);
+    write("docs/clean.md", SUBSTANTIVE);
+
+    const r = runCli(["verify", "--files", "docs/clean.md"]);
+
+    const combined = `${r.stdout}\n${r.stderr}`;
+    assert.match(
+      combined,
+      /DSPy evaluation failed|ECONNREFUSED/,
+      "without the flag, DSPy IS attempted and the failure is surfaced (this proves the previous test's silence is meaningful)",
+    );
+  });
+});
+
+describe("verify --dry-run-dspy — exit code parity", () => {
+  it("clean substantive doc → exit 0 (matches no-flag run)", () => {
+    write("defense.config.yml", DSPY_ENABLED_CLOSED_PORT_CONFIG);
+    write("docs/clean.md", SUBSTANTIVE);
+
+    const r = runCli(["verify", "--dry-run-dspy", "--files", "docs/clean.md"]);
+
+    assert.equal(
+      r.status,
+      0,
+      `expected exit 0 on clean doc; got status=${r.status}\nstdout=${r.stdout}\nstderr=${r.stderr}`,
+    );
+  });
+
+  it("hollow artifact → exit 1 (L1 BLOCK fires regardless of flag)", () => {
+    write("defense.config.yml", DSPY_ENABLED_CLOSED_PORT_CONFIG);
+    write("docs/hollow.md", `${SUBSTANTIVE}\n\nTODO: write the rest`);
+
+    const r = runCli([
+      "verify",
+      "--dry-run-dspy",
+      "--files",
+      "docs/hollow.md",
+    ]);
+
+    assert.equal(
+      r.status,
+      1,
+      "L1 BLOCK must still fire when DSPy is dry-run-disabled",
+    );
+    assert.match(
+      r.stdout,
+      /Hollow Artifact/,
+      "hollow-artifact guard finding must surface in stdout",
+    );
+  });
+});
+
+describe("verify --dry-run-dspy — flag combinations", () => {
+  it("works after --files <paths>", () => {
+    write("defense.config.yml", DSPY_ENABLED_CLOSED_PORT_CONFIG);
+    write("docs/clean.md", SUBSTANTIVE);
+
+    const r = runCli([
+      "verify",
+      "--files",
+      "docs/clean.md",
+      "--dry-run-dspy",
+    ]);
+
+    assert.equal(r.status, 0);
+    assert.match(r.stderr, /--dry-run-dspy/);
+  });
+
+  it("works before --files <paths>", () => {
+    write("defense.config.yml", DSPY_ENABLED_CLOSED_PORT_CONFIG);
+    write("docs/clean.md", SUBSTANTIVE);
+
+    const r = runCli([
+      "verify",
+      "--dry-run-dspy",
+      "--files",
+      "docs/clean.md",
+    ]);
+
+    assert.equal(r.status, 0);
+    assert.match(r.stderr, /--dry-run-dspy/);
+  });
+});
+
+describe("--help mentions --dry-run-dspy", () => {
+  it("printUsage() includes the flag and a short explanation", () => {
+    const r = runCli(["--help"]);
+
+    assert.equal(r.status, 0);
+    assert.match(
+      r.stdout,
+      /--dry-run-dspy/,
+      "--help must document the new flag",
+    );
+    assert.match(
+      r.stdout,
+      /DSPy/,
+      "--help should explain what the flag does",
+    );
+  });
+});


### PR DESCRIPTION
## Description

Implements the maintainer-approved plan on issue #15. Adds a `--dry-run-dspy` flag to `verify` so users can validate that their L1+L2 governance still passes when the DSPy semantic layer is offline — without editing config files or environment variables.

Fixes #15

## Type of Change

- [x] ✨ New feature (non-breaking)
- [x] 📝 Documentation only — *partial; new section in `docs/dev-guide/dspy-providers.md`*

## Behavior

When `--dry-run-dspy` is passed to `verify`:

1. The current `defense.config.yml` is loaded.
2. `config.guards.hollowArtifact.useDspy` is set to `false` for this run only — no on-disk config change, no env variable.
3. A banner is written to **stderr** via `process.stderr.write` (NOT `console.error`, per maintainer Q2 — `console.error` adds Node-version-dependent timestamps that would break the CI assertion):

   ```
   ⚠  --dry-run-dspy: DSPy semantic evaluation skipped
   ```
4. The engine is constructed with the mutated config and runs as normal. L1 (regex) + L2 (length) findings continue to be authoritative.

The flag affects **only** `verify`. `eval <file>` still requires DSPy because semantic evaluation is its primary purpose (per maintainer Q1).

## Acceptance Criteria — issue #15

| AC | Where |
|---|---|
| Flag parsed in `verify` | `src/cli/verify.ts` |
| Sets `useDspy = false` before `engine.run()` | `src/cli/verify.ts` line ~50 |
| Banner logged to stderr | `process.stderr.write(...)` |
| **No** DSPy call made when flag is set | proven by network-absence test |
| Docs update | `docs/dev-guide/dspy-providers.md` — new "Testing your fallback" section |
| `--help` output updated | `src/cli/index.ts` `printUsage()` |
| Banner wording approved | `⚠  --dry-run-dspy: DSPy semantic evaluation skipped` |

## Open Questions resolved (per maintainer comment)

- **Q1** Flag scope → `verify` only. ✅ (eval / lesson record stay untouched)
- **Q2** Banner wording → approved with `--dry-run-dspy` prefix; emit via `process.stderr.write`. ✅
- **Q3** Stub-helper dependency on #14 → inline `closedPort = 1` (port 1 is reserved/closed on common OSes). ✅

## Anti-hallucination test design

The central assertion is that `--dry-run-dspy` actually prevents the DSPy network call. Test strategy:

1. Write a `defense.config.yml` with `useDspy: true` and `dspyEndpoint: http://127.0.0.1:1/evaluate` (port 1 is reserved/closed everywhere).
2. Run `verify --dry-run-dspy`. Assert stderr contains the banner AND **does not** contain `ECONNREFUSED` or `DSPy evaluation failed`.
3. Control case: run the same config **without** the flag. Assert stderr **does** surface `ECONNREFUSED` / `DSPy evaluation failed` — proving the silence in step 2 was meaningful.

If callDspy() were still being invoked when the flag is set, the closed port would emit a `DSPy evaluation failed for artifact:<file>: ... ECONNREFUSED ...` warning. Its absence is positive evidence that the flag works.

## Checklist

- [x] My code follows the [consistency rules](.agents/rules/rule-consistency.md)
- [x] I used conventional commit format for the PR title
- [x] I added tests for new functionality
- [x] All existing tests pass (`npm test`)
- [x] I updated documentation (README, CHANGELOG) if needed — `docs/dev-guide/dspy-providers.md` updated
- [x] No `any` types used
- [x] No new external dependencies added

## Evidence

```
$ npm run lint
> tsc --noEmit
(exit 0)

$ npm test
…
ℹ tests 286
ℹ pass 286
ℹ fail 0
ℹ duration_ms 12465
```

286 = 277 baseline (post #6–#12 merge) + 9 new (3 banner output, 2 network-absence, 2 exit-code parity, 2 flag-combo, 1 `--help`).

## Manual verification

```bash
$ npx defense-in-depth verify --dry-run-dspy --files docs/clean.md 2>&1 1>/dev/null
⚠  --dry-run-dspy: DSPy semantic evaluation skipped

$ npx defense-in-depth --help | grep -A1 dry-run
  --dry-run-dspy    Force-disable DSPy semantic evaluation for this run.
                    Useful for verifying L1+L2 governance still passes when
                    your DSPy endpoint is offline. Banner is written to stderr.
```

Executor: Devin-AI


Link to Devin session: https://app.devin.ai/sessions/1e8caa3cff7c42a7937fb2fce832fcfe
Requested by: @tamld
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tamld/defense-in-depth/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
