### PR TITLE
docs(skills): port skill-impact-predictor — pre-implementation blast-radius analysis

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -69,6 +69,8 @@ flowchart TD
 │   │   └── SKILL.md           (growth engine — 5-phase reflection)
 │   ├── skill-deep-research/
 │   │   └── SKILL.md           (research pipeline with cross-check)
+│   ├── skill-impact-predictor/
+│   │   └── SKILL.md           (pre-implementation blast-radius analysis)
 │   └── _template/
 │       └── SKILL.md
 ├── config/                    # Machine-readable configs

--- a/.agents/skills/AGENTS.md
+++ b/.agents/skills/AGENTS.md
@@ -38,6 +38,7 @@ Threat modeling a new check       → skill-threat-modeling-expert/SKILL.md
 Writing adversarial tests         → skill-test-architect/SKILL.md
 Code review of a PR               → skill-review-code/SKILL.md
 Refactoring existing guard code   → skill-surgical-refactorer/SKILL.md
+Mapping blast radius of a change  → skill-impact-predictor/SKILL.md
 CI/CD pipeline or GitHub Actions  → skill-devops-github-actions/SKILL.md
 DSPy evaluation quality / tuning  → skill-ai-dspy-validator/SKILL.md
 ```
@@ -53,6 +54,7 @@ DSPy evaluation quality / tuning  → skill-ai-dspy-validator/SKILL.md
 | [skill-test-architect](skill-test-architect/SKILL.md) | Testing | Adversarial test design |
 | [skill-review-code](skill-review-code/SKILL.md) | Quality | PR code review |
 | [skill-surgical-refactorer](skill-surgical-refactorer/SKILL.md) | Refactoring | Safe guard refactors |
+| [skill-impact-predictor](skill-impact-predictor/SKILL.md) | Governance | Pre-implementation blast-radius analysis |
 | [skill-devops-github-actions](skill-devops-github-actions/SKILL.md) | CI/CD | GitHub Actions / CI gates |
 | [skill-ai-dspy-validator](skill-ai-dspy-validator/SKILL.md) | Intelligence | DSPy eval quality |
 

--- a/.agents/skills/skill-impact-predictor/SKILL.md
+++ b/.agents/skills/skill-impact-predictor/SKILL.md
@@ -87,12 +87,14 @@ Apply the rules in order; first match wins.
 
 | Rule | Risk |
 |:--|:--|
+| Direct target mutates the `Finding.severity` contract or registry shape | HIGH |
 | Direct target is a public-API file AND inbound consumers > 5 | HIGH |
 | Direct target is a Guard (`src/guards/*.ts`) with 0 strict-import tests | HIGH |
 | Direct target modifies an exported type/interface in `src/core/types.ts` | HIGH |
 | Inbound consumers (1st + 2nd degree) > 20 | MEDIUM |
-| Direct target mutates the `Finding.severity` contract or registry shape | HIGH |
 | All other cases | LOW |
+
+All HIGH rules are listed before any MEDIUM rule so that "first match wins" cannot let a lower severity shadow a non-negotiable HIGH. New HIGH conditions added in future revisions MUST stay above the MEDIUM row.
 
 The `Finding.severity` rule is non-negotiable per `SKILL_STANDARDS.md` §DiD-Specific Constraints — severity changes propagate to every CI gate consumer and to the federation child report shape.
 

--- a/.agents/skills/skill-impact-predictor/SKILL.md
+++ b/.agents/skills/skill-impact-predictor/SKILL.md
@@ -1,0 +1,149 @@
+---
+domain: governance
+name: skill-impact-predictor
+description: Trace import graph + test coverage of files about to be modified and produce an impact report before any code changes are made.
+version: 1.0.0
+type: specialist
+role: The Blast Radius Calculator
+---
+
+# SKILL: skill-impact-predictor
+
+## Identity
+
+**Role**: The Blast Radius Calculator
+**Philosophy**: Every change to a Guard or core module has a blast radius. Mapping it before editing prevents the silent regressions that this project's pre-commit pipeline cannot catch.
+
+---
+
+## Mission
+
+Before any implementation begins on a DiD change, trace the dependency graph of the files about to be modified and produce a structured impact report that captures:
+
+1. **Direct targets** — the files the agent intends to edit.
+2. **Inbound consumers** — every file that imports or re-exports a direct target.
+3. **Test coverage** — which tests under `tests/` exercise each direct target.
+4. **Risk level** — LOW / MEDIUM / HIGH per the rules in §Workflow Step 5.
+5. **Recommendation** — proceed, split the work, or write tests first.
+
+The skill is a **planning artifact**. It runs before the diff exists. Running it after coding is theater and does not satisfy the hard gates below.
+
+---
+
+## Hard Gates
+
+| ID | Gate | If FAIL |
+|:--:|:--|:--|
+| G1 | Run BEFORE any source edit. The agent's working tree must be clean (or contain only doc edits) when the report is produced. | STOP — post-hoc analysis is rejected. |
+| G2 | The report cites real files in `src/`, `tests/`, or `.agents/`. No invented paths. | STOP — re-run discovery with `grep`/`rg`. |
+| G3 | If a direct target is a public-API file (`src/core/types.ts`, `src/core/engine.ts`, `src/guards/index.ts`, `src/cli/index.ts`) AND risk is HIGH AND test coverage of the target is below 70% by file count, BLOCK and demand tests first. | BLOCK — return to issue queue. |
+| G4 | If blast radius (direct + inbound consumers) exceeds 50 files, HALT and require splitting the work into smaller issues. | HALT — open child issues, do not proceed in one PR. |
+| G5 | The skill must NOT widen its scope into refactoring, fixing unrelated issues, or modifying tests of unrelated modules. Pure analysis only. | STOP — file separate issues for collateral findings. |
+
+---
+
+## Workflow
+
+### Step 1 — Define the explicit target list
+
+Read the issue / PR description. Extract every file path the agent intends to edit. If the description says only "fix the federation guard", expand to a concrete list (e.g. `src/guards/federation.ts`, `src/federation/file-provider.ts`) and confirm with the human before continuing.
+
+### Step 2 — Trace inbound consumers (1st degree)
+
+For each direct target, find every file that imports it.
+
+```bash
+# In repo root
+rg -l "from ['\"][^'\"]*<basename>['\"]" --type ts src tests
+rg -l "require\\(['\"][^'\"]*<basename>['\"]\\)" src tests
+```
+
+Record the absolute count and the file list. Pay special attention to:
+- `src/guards/index.ts` (barrel export — touching it ripples to every guard consumer)
+- `src/core/types.ts` (Guard interface — touching it ripples to every guard)
+- `src/core/engine.ts` (pipeline runner — touching it ripples to every CLI command)
+- `src/cli/index.ts` (CLI router — touching it ripples to all `did *` subcommands)
+
+### Step 3 — Trace 2nd-degree consumers
+
+For every 1st-degree consumer, repeat Step 2. Stop at depth 2 unless the human asks for deeper. Cap the union of 1st + 2nd degree at 50 files (G4).
+
+### Step 4 — Map test coverage
+
+For each direct target, identify test files that exercise it.
+
+```bash
+# Strict: tests that import the target by relative path
+rg -l "from ['\"]\\.\\./.*<basename>['\"]" tests
+# Loose: tests that mention the basename anywhere
+rg -l "<basename>" tests
+```
+
+Record both counts. A direct target with 0 strict-import tests is a **coverage gap** even if loose mentions exist.
+
+### Step 5 — Score risk
+
+Apply the rules in order; first match wins.
+
+| Rule | Risk |
+|:--|:--|
+| Direct target is a public-API file AND inbound consumers > 5 | HIGH |
+| Direct target is a Guard (`src/guards/*.ts`) with 0 strict-import tests | HIGH |
+| Direct target modifies an exported type/interface in `src/core/types.ts` | HIGH |
+| Inbound consumers (1st + 2nd degree) > 20 | MEDIUM |
+| Direct target mutates the `Finding.severity` contract or registry shape | HIGH |
+| All other cases | LOW |
+
+The `Finding.severity` rule is non-negotiable per `SKILL_STANDARDS.md` §DiD-Specific Constraints — severity changes propagate to every CI gate consumer and to the federation child report shape.
+
+### Step 6 — Emit the report
+
+Write the report to the location agreed with the human (typically a comment on the issue or a scratch file the agent links from the PR). Use this exact structure:
+
+```markdown
+# Impact Report — <issue or PR id>
+
+## Direct targets
+- src/...
+- src/...
+
+## Inbound consumers (1st degree, count = N)
+- src/...
+- src/...
+
+## Inbound consumers (2nd degree, count = M)
+- src/...
+
+## Test coverage (strict imports)
+| Target | Strict-import tests | Loose mentions |
+|:--|:-:|:-:|
+| src/... | tests/... | ... |
+
+## Risk level
+HIGH | MEDIUM | LOW — <one-sentence justification>
+
+## Recommendation
+proceed | split (open child issues #X, #Y) | write tests first
+```
+
+---
+
+## Output Contract
+
+| Item | Requirement |
+|:--|:--|
+| Working tree state when the report is produced | Clean of source edits (G1). |
+| File paths in the report | All cited files exist on disk in this repo (G2). |
+| Risk level | One of HIGH / MEDIUM / LOW with a one-sentence justification grounded in §Workflow Step 5. |
+| Recommendation | Aligned with the gates: HIGH + low coverage → "write tests first"; > 50 files → "split"; otherwise "proceed". |
+| Evidence tag for each citation | `[CODE]` when the file exists on disk. Never `[HYPO]`. |
+
+---
+
+## Anti-Patterns
+
+1. **Post-hoc impact reports.** Running the skill after the diff is already written produces a description of what changed, not a prediction of what could break. The whole value is pre-implementation.
+2. **Stopping at direct imports.** Touching `src/core/types.ts` looks like a 3-file change until you trace the Guard interface ripple — every file in `src/guards/` becomes 1st-degree, every test in `tests/` becomes 2nd-degree. Always trace depth 2 for type/interface changes.
+3. **Treating loose `rg` mentions as test coverage.** A test file that mentions `"federation"` in a string literal is not coverage. Coverage requires a strict import of the target module under test.
+4. **Splitting the report across the PR description and the commit message.** The report is a single artifact. If it does not fit the PR description, link to a scratch file in the PR comments.
+5. **Allowing the skill to bleed into refactoring.** The moment the agent edits a file outside the discovery commands above, the report is invalidated by G1. Refactor work belongs in `skill-surgical-refactorer` after the report is approved.


### PR DESCRIPTION
## Description

Adds `skill-impact-predictor` to `.agents/skills/`. The skill instructs an AI agent to trace the import graph + test coverage of files it intends to modify, score the risk, and emit a structured Impact Report **before** any source edit. The skill is a pure planning artefact — it produces no code change.

This is the **second PR in the Phase 0 skill + CI port initiative** agreed in this session, after PR #46 (Git Shield CI). Per the user's choice of "Option B" during planning, only `skill-impact-predictor` is being ported in Phase 0; `skill-scout-prime` and `skill-seekers` were dropped to avoid overlap with `skill-deep-research` and to keep the surface narrow.

Source pattern: `web-login-solo/.agents/skills/skill-impact-predictor/SKILL.md@v2.0.0`. The file was rewritten (not pasted) to satisfy `.agents/skills/AGENTS.md` and `.agents/skills/SKILL_STANDARDS.md`.

Fixes # _(no tracking issue — this PR is the artefact for the Phase 0 commitment in PR #46's session)_

## Type of Change

- [ ] 🐛 Bug fix (non-breaking)
- [ ] ✨ New feature (non-breaking)
- [ ] 🛡️ New guard
- [ ] 💥 Breaking change
- [x] 📝 Documentation only
- [ ] 🔧 Refactor (no behavior change)

No source code is touched. No CI gate is changed. No npm package surface is changed.

## What's added

### `.agents/skills/skill-impact-predictor/SKILL.md`

Sections, in the order required by `SKILL_STANDARDS.md`:

1. **Identity** — role + philosophy.
2. **Mission** — what the skill enables.
3. **Hard Gates** (G1–G5) — pre-implementation only, real-paths-only, public-API + low-coverage = BLOCK, > 50 files = HALT, no scope bleed.
4. **Workflow** (Steps 1–6) — explicit `rg`/`grep` recipes, depth-2 trace, strict-import vs loose-mention coverage distinction, risk scoring table, report template.
5. **Output Contract** — what the agent must produce when the skill is complete.
6. **Anti-Patterns** — five governance-middleware-specific failure modes.

### `.agents/skills/AGENTS.md`

Two registration entries:

- Routing table line: `Mapping blast radius of a change → skill-impact-predictor/SKILL.md`.
- Skill index row in the Domain table.

## Why DiD needs this skill

This session itself produced two skip-discovery failures that this skill would have prevented:

| Failure | What the skill would have caught |
|:--|:--|
| Issue #42 opened as Track A3 umbrella without checking that #33–#39 were already prerequisites for the same work. | A 1st-degree consumer trace on "API surface" would have surfaced #33–#39 as inbound dependencies of the proposed scope. |
| PR #46 ported a CI workflow with `--no-git` flag without verifying its behaviour in DiD's context (the flag silently disabled history scanning). | The pre-implementation report would have listed `CI behavioural correctness unverified` as a missing artefact and flagged the port as MEDIUM-risk → "write a reproduction first". |

Beyond this session, DiD's own files (`src/core/types.ts`, `src/guards/index.ts`, `src/core/engine.ts`, `src/cli/index.ts`) are textbook public-API targets where uncomputed blast radius is the dominant regression risk for every future contributor — human or agent.

## DiD-shape adaptations vs source

| Aspect | Source (`web-login-solo`) | This PR (DiD) | Reason |
|:--|:--|:--|:--|
| `domain:` frontmatter | `governance` | `governance` | Already aligned — no change. |
| Trigger conditions | Prose paragraph | Five explicit Hard Gates (G1–G5) | Match `skill-surgical-refactorer`'s structure; `SKILL_STANDARDS.md` requires "Hard Gates" as a section. |
| File citations in Workflow | Generic `<module_name>` | Real DiD paths (`src/core/types.ts`, `src/guards/index.ts`, `src/core/engine.ts`, `src/cli/index.ts`) | `SKILL_STANDARDS.md` DiD-Specific Constraint #3 (cite real source files). |
| Ticket framing | `ticket plan`, `Captain Planner`, `captain-planner` | GitHub issue / PR description | DiD doesn't run an `ag` ticket lifecycle — agents operate on issues and PRs. AAOS-specific captain skills are forbidden per `.agents/skills/AGENTS.md`. |
| Severity rule | Not present | Explicit `Finding.severity` clause in Step 5 | `SKILL_STANDARDS.md` DiD-Specific Constraint #2 (severity is a hard contract). |
| Anti-patterns | Three generic ("Skipping impact analysis on small changes…") | Five governance-middleware-specific (`types.ts` ripple, loose `rg` vs strict imports, scope bleed into refactoring, etc.) | `SKILL_STANDARDS.md` DiD-Specific Constraint #4 (≥ 3 failure modes, no generic platitudes). |
| Coverage check | Single loose `grep` | Strict-import + loose-mention split; only strict counts as coverage | False-positive coverage was a real failure mode I observed in this session. |

## Discipline notes (per session contract)

Per `AGENTS.md` Layer 4, `.agents/**` is a forbidden zone for AI agents without explicit human instruction. This PR is opened under the explicit instruction received in the originating session, where the user selected **Option B** (port only `skill-impact-predictor`, drop `skill-scout-prime` and `skill-seekers`) after the constraints in `.agents/skills/AGENTS.md` and `SKILL_STANDARDS.md` were surfaced.

The source skill from `web-login-solo` was **rewritten end-to-end**, not pasted. Rationale lines per adaptation are in the table above and in the commit message.

No external runtime dependency added. No source code changed. No test changed. The skill is consumed only by AI agents reading the file at task time — it does not enter the runtime engine.

## Checklist

- [x] My code follows the [consistency rules](.agents/rules/rule-consistency.md)
- [x] I used conventional commit format for the PR title
- [ ] I added tests for new functionality (N/A — `.md` skill file has no executable surface; lint runs over the file via gitleaks + CodeRabbit)
- [x] All existing tests pass (no source change)
- [x] I updated documentation (`.agents/skills/AGENTS.md` registry entries added)
- [x] No `any` types used (N/A — Markdown)
- [x] No new external dependencies added

## Evidence

Hollow-artefact regex (the same regex `rule-zero-theater.md` enforces) on the new and modified files:

```
$ grep -niE 'TODO|TBD|PLACEHOLDER|FILL.*IN|INSERT.*HERE|FIXME|XXX' \
    .agents/skills/skill-impact-predictor/SKILL.md \
    .agents/skills/AGENTS.md
CLEAN
```

`SKILL_STANDARDS.md` required-section check:

```
$ grep -E '^## (Identity|Mission|Hard Gates|Workflow|Output Contract|Anti-Patterns)' \
    .agents/skills/skill-impact-predictor/SKILL.md
## Identity
## Mission
## Hard Gates
## Workflow
## Output Contract
## Anti-Patterns
```

All six required sections present, in order.

## Out of scope

- `skill-scout-prime` and `skill-seekers` ports (deferred per Option B).
- A `did skill list` / `did skill check` CLI to expose skills to end users (separate Phase 2 tracking issue, to be opened after this PR).
- A Phase 1 skill-port roadmap (gated on Track A4 adoption signal — separate tracking issue, to be opened after this PR).

Link to Devin session: https://app.devin.ai/sessions/2e05b451daf34260887e8d859e9d2909
Requested by: @tamld
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tamld/defense-in-depth/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
