### PR TITLE
feat(api): complete type exports + fix missing guard re-exports (closes #33)

### DIFF
--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -328,13 +328,4 @@ export class DefendEngine {
   }
 }
 
-// Re-export everything consumers need
-export { Severity } from "./types.js";
-export type {
-  Guard,
-  GuardContext,
-  GuardResult,
-  EngineVerdict,
-  DefendConfig,
-  Finding,
-} from "./types.js";
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,14 @@
  *   npx defense-in-depth doctor
  */
 
+// ─── Engine + Config ───
 export { DefendEngine } from "./core/engine.js";
 export { loadConfig, DEFAULT_CONFIG } from "./core/config-loader.js";
-export { Severity } from "./core/types.js";
+
+// ─── Core enums ───
+export { Severity, EvidenceLevel } from "./core/types.js";
+
+// ─── Core types ───
 export type {
   Guard,
   GuardContext,
@@ -20,22 +25,41 @@ export type {
   EngineVerdict,
   Finding,
   DefendConfig,
+  TicketRef,
+  Lesson,
+  EvaluationScore,
+  GuardF1Metric,
+  DSPyConfig,
+  FeedbackEvent,
+} from "./core/types.js";
+
+// ─── Per-guard configuration types ───
+export type {
+  HollowArtifactConfig,
+  SsotPollutionConfig,
+  RootPollutionConfig,
+  CommitFormatConfig,
+  BranchNamingConfig,
+  PhaseGateConfig,
+  TicketIdentityConfig,
+  HitlReviewConfig,
   FederationGuardConfig,
 } from "./core/types.js";
 
-// Guards
+// ─── Built-in guards ───
 export {
   hollowArtifactGuard,
   ssotPollutionGuard,
+  rootPollutionGuard,
   commitFormatGuard,
   branchNamingGuard,
   phaseGateGuard,
   ticketIdentityGuard,
+  hitlReviewGuard,
   federationGuard,
   allBuiltinGuards,
 } from "./guards/index.js";
 
-// Federation (v0.3 → v0.6)
+// ─── Federation (v0.3 → v0.6) ───
 export { createProvider, FileTicketProvider, HttpTicketProvider } from "./federation/index.js";
 export type { TicketStateProvider } from "./federation/types.js";
-export type { TicketRef } from "./core/types.js";

--- a/tests/public-api.test.js
+++ b/tests/public-api.test.js
@@ -1,0 +1,161 @@
+/**
+ * Smoke tests for the public API surface (`import ... from "defense-in-depth"`).
+ *
+ * Spec: issue #33 — every shipped guard and every public type must be
+ * reachable through the barrel file. This file imports the package via
+ * its compiled barrel (`dist/index.js`) — the same path that external
+ * consumers hit when they `npm install defense-in-depth` and
+ * `import { ... } from "defense-in-depth"`.
+ *
+ * If a future change drops a re-export, these tests fail before the
+ * change reaches a consumer's `node_modules`.
+ *
+ * Executor: Devin
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import * as publicApi from "../dist/index.js";
+
+import {
+  // Engine + Config (values)
+  DefendEngine,
+  loadConfig,
+  DEFAULT_CONFIG,
+  // Enums (values)
+  Severity,
+  EvidenceLevel,
+  // Built-in guards (values)
+  hollowArtifactGuard,
+  ssotPollutionGuard,
+  rootPollutionGuard,
+  commitFormatGuard,
+  branchNamingGuard,
+  phaseGateGuard,
+  ticketIdentityGuard,
+  hitlReviewGuard,
+  federationGuard,
+  allBuiltinGuards,
+  // Federation (values)
+  createProvider,
+  FileTicketProvider,
+  HttpTicketProvider,
+} from "../dist/index.js";
+
+describe("public API barrel — runtime values", () => {
+  it("re-exports the engine constructor", () => {
+    assert.equal(typeof DefendEngine, "function");
+    assert.equal(DefendEngine.name, "DefendEngine");
+  });
+
+  it("re-exports loadConfig + DEFAULT_CONFIG", () => {
+    assert.equal(typeof loadConfig, "function");
+    assert.equal(typeof DEFAULT_CONFIG, "object");
+    assert.ok(DEFAULT_CONFIG.guards, "DEFAULT_CONFIG must contain a `guards` block");
+  });
+
+  it("re-exports the Severity enum with the documented members", () => {
+    assert.equal(typeof Severity, "object");
+    assert.equal(Severity.PASS, "pass");
+    assert.equal(Severity.WARN, "warn");
+    assert.equal(Severity.BLOCK, "block");
+  });
+
+  it("re-exports the EvidenceLevel enum with the documented members", () => {
+    assert.equal(typeof EvidenceLevel, "object");
+    assert.equal(EvidenceLevel.CODE, "CODE");
+    assert.equal(EvidenceLevel.RUNTIME, "RUNTIME");
+    assert.equal(EvidenceLevel.INFER, "INFER");
+    assert.equal(EvidenceLevel.HYPO, "HYPO");
+  });
+});
+
+describe("public API barrel — built-in guards", () => {
+  const guardCases = [
+    ["hollowArtifactGuard", hollowArtifactGuard, "hollowArtifact"],
+    ["ssotPollutionGuard", ssotPollutionGuard, "ssotPollution"],
+    ["rootPollutionGuard", rootPollutionGuard, "rootPollution"],
+    ["commitFormatGuard", commitFormatGuard, "commitFormat"],
+    ["branchNamingGuard", branchNamingGuard, "branchNaming"],
+    ["phaseGateGuard", phaseGateGuard, "phaseGate"],
+    ["ticketIdentityGuard", ticketIdentityGuard, "ticketIdentity"],
+    ["hitlReviewGuard", hitlReviewGuard, "hitlReview"],
+    ["federationGuard", federationGuard, "federation"],
+  ];
+
+  for (const [exportName, guard, expectedId] of guardCases) {
+    it(`${exportName} satisfies the Guard interface`, () => {
+      assert.equal(typeof guard, "object");
+      assert.equal(typeof guard.check, "function");
+      assert.equal(guard.id, expectedId, `${exportName}.id must be "${expectedId}"`);
+    });
+  }
+
+  it("allBuiltinGuards is a frozen-shape array containing every built-in guard", () => {
+    assert.ok(Array.isArray(allBuiltinGuards));
+    assert.equal(
+      allBuiltinGuards.length,
+      guardCases.length,
+      `allBuiltinGuards must contain ${guardCases.length} guards (one per built-in)`,
+    );
+    for (const [, guard] of guardCases) {
+      assert.ok(
+        allBuiltinGuards.includes(guard),
+        `allBuiltinGuards must include ${guard.id}`,
+      );
+    }
+  });
+});
+
+describe("public API barrel — federation entry points", () => {
+  it("re-exports createProvider", () => {
+    assert.equal(typeof createProvider, "function");
+  });
+
+  it("re-exports FileTicketProvider class", () => {
+    assert.equal(typeof FileTicketProvider, "function");
+    assert.equal(FileTicketProvider.name, "FileTicketProvider");
+  });
+
+  it("re-exports HttpTicketProvider class", () => {
+    assert.equal(typeof HttpTicketProvider, "function");
+    assert.equal(HttpTicketProvider.name, "HttpTicketProvider");
+  });
+});
+
+describe("public API barrel — module shape", () => {
+  it("does not leak unexpected runtime exports", () => {
+    // Allow-list of every value-level export the public API ships.
+    // Type-only exports (Guard, GuardContext, Lesson, ...) are erased
+    // at runtime, so they never appear here.
+    const expected = new Set([
+      "DefendEngine",
+      "loadConfig",
+      "DEFAULT_CONFIG",
+      "Severity",
+      "EvidenceLevel",
+      "hollowArtifactGuard",
+      "ssotPollutionGuard",
+      "rootPollutionGuard",
+      "commitFormatGuard",
+      "branchNamingGuard",
+      "phaseGateGuard",
+      "ticketIdentityGuard",
+      "hitlReviewGuard",
+      "federationGuard",
+      "allBuiltinGuards",
+      "createProvider",
+      "FileTicketProvider",
+      "HttpTicketProvider",
+    ]);
+
+    const actual = new Set(Object.keys(publicApi));
+
+    const unexpected = [...actual].filter((k) => !expected.has(k));
+    const missing = [...expected].filter((k) => !actual.has(k));
+
+    assert.deepEqual(unexpected, [], `unexpected runtime exports leaked: ${unexpected.join(", ")}`);
+    assert.deepEqual(missing, [], `expected runtime exports missing: ${missing.join(", ")}`);
+  });
+});


### PR DESCRIPTION
## Description

**Track A2 — foundation API completion.** Position #2 in the canonical execution order pinned in [umbrella #42](https://github.com/tamld/defense-in-depth/issues/42). Last public-API change before the **v1.0.0-rc.1** cut.

Fixes #33

`src/index.ts` was missing **2 built-in guards** (`rootPollutionGuard`, `hitlReviewGuard`) and **a long list of public types** (`EvidenceLevel`, `Lesson`, `EvaluationScore`, `GuardF1Metric`, `DSPyConfig`, `FeedbackEvent`, plus all 8 per-guard config interfaces) that v0.4–v0.7 already shipped. Library consumers had to reach into deep `dist/...` paths. This PR completes the barrel surface, drops the dead `Severity` re-export from `engine.ts`, and adds the first smoke test for the public API.

### Self-applied skill before edit

Per the discipline contract, [`skill-impact-predictor` v1.0.1](.agents/skills/skill-impact-predictor/SKILL.md) was self-applied **before** any source edit. Working tree was clean (G1 ✓), targets extracted from issue (G2 ✓), `src/index.ts` is the library entry point so G3 fires — additive changes plus required smoke test bring barrel coverage to 100% (G3 satisfied), 3 files in the diff well below 50-file blast (G4 ✓), no scope widening (G5 ✓).

Full Impact Report posted on [#33 comment](https://github.com/tamld/defense-in-depth/issues/33#issuecomment-4331277333) — risk graded LOW, recommendation **proceed**.

### What changed

#### Commit 1 — `feat(api): re-export 2 missing guards + 8 missing public types`

`src/index.ts` reorganised into clearly labelled sections so the public surface is legible at a glance: Engine + Config / Core enums / Core types / Per-guard configuration / Built-in guards / Federation. New value-level exports: `EvidenceLevel`, `rootPollutionGuard`, `hitlReviewGuard`. New type-only exports: `Lesson`, `EvaluationScore`, `GuardF1Metric`, `DSPyConfig`, `FeedbackEvent`, `HollowArtifactConfig`, `SsotPollutionConfig`, `RootPollutionConfig`, `CommitFormatConfig`, `BranchNamingConfig`, `PhaseGateConfig`, `TicketIdentityConfig`, `HitlReviewConfig`. (`FederationGuardConfig` was already exported.)

#### Commit 2 — `refactor(engine): drop dead Severity re-export — types.ts is the SSoT`

`src/core/engine.ts` ended with a 9-line tail re-exporting `Severity` and 6 type aliases from `./types.js`. **Verified zero callers across the entire repo** — every `Severity` consumer (27 sites: src/guards/*.ts, src/cli/verify.ts, all tests, README, writing-guards.md, skill-guard-governance/SKILL.md) imports from `core/types.js` (or `dist/core/types.js` in tests). Removing the dead re-export makes "one type, one home" the actual contract:

- `src/core/types.ts` = SSoT for all types and enums
- `src/index.ts` = public barrel re-exporting from types.ts + guards
- `src/core/engine.ts` = exports only `DefendEngine` (its sole responsibility)

This also unblocks the v1.0 `package.json exports` work (#36): with `Severity` available via only one path, the subpath exports field can list `core/types` as a stable subpath without ambiguity.

#### Commit 3 — `test(public-api): smoke tests for every public export`

New `tests/public-api.test.js` (161 lines, 18 tests) — the first test file that imports through the package barrel `dist/index.js` (the same path external consumers hit) instead of reaching into `dist/core/types.js` directly. Module-shape allow-list test is the trip-wire that protects v1.0.0-rc.1 API freeze: any future PR that adds, removes, or renames a value-level runtime export will fail this test until the allow-list is updated in the same commit.

### Acceptance criteria (from #33)

- [x] All 9 built-in guards re-exported from `src/index.ts`
- [x] All public types listed in #33 exported from `src/index.ts`
- [x] `Severity` exported only from `src/index.ts`, not `engine.ts`
- [x] No `any` types in any export
- [x] Existing tests still pass — 384/384 (was 366 + 18 new)
- [x] Smoke test imports `rootPollutionGuard`, `hitlReviewGuard`, `EvidenceLevel` from `../dist/index.js`

### Out of scope (per umbrella #42 sequencing)

- No `package.json` `exports` field change → that's #36
- No typed error class hierarchy → that's #37
- No migration guide → that's #34 (depends on the locked surface this PR ships)
- No npm `latest` promo → that's the v1.0 GA cut

## Type of Change

- [x] ✨ New feature (non-breaking)
- [x] 🔧 Refactor (no behavior change)

(Both apply: additive re-exports in `src/index.ts` are a non-breaking new feature; dropping the dead `Severity` re-export from `engine.ts` is a no-behaviour-change refactor — see Commit 2 for the zero-caller verification.)

## Checklist

- [x] My code follows the [consistency rules](.agents/rules/rule-consistency.md)
- [x] I used conventional commit format for the PR title
- [x] I added tests for new functionality
- [x] All existing tests pass (`npm test`)
- [ ] I updated documentation (README, CHANGELOG) if needed — README already references `import { Severity } from "defense-in-depth"` (line 348); CHANGELOG entry deferred to the v1.0.0-rc.1 cut PR per umbrella #42 release engineering steps
- [x] New guards implement the `Guard` interface from `core/types.ts` — N/A (no new guards)
- [x] No `any` types used
- [x] No new external dependencies added

## For New Guards Only

N/A — this PR re-exports existing guards, does not introduce new ones.

## Evidence

```
$ git diff --stat main..HEAD
 src/core/engine.ts          | 11 +------
 src/index.ts                | 32 ++++++++++++++++----
 tests/public-api.test.js    | 161 +++++++++++++++++++++++++++++++++++++++++++

$ npm test
...
tests 384  pass 384  fail 0  duration_ms 27521

$ npm run lint   # tsc --noEmit
(exit 0, no output)

$ rg "from\s+['\"][^'\"]*engine(\.js)?['\"]"
src/cli/{verify,doctor,hints-emit}.ts -> import DefendEngine only
src/index.ts                          -> export { DefendEngine } only
tests/{engine,engine-federation,...}  -> import DefendEngine only
# No consumer imports Severity via engine.js — confirms the Commit-2 refactor is safe.
```

Executor: Devin (self-applied skill-impact-predictor v1.0.1)

Link to Devin session: https://app.devin.ai/sessions/2e05b451daf34260887e8d859e9d2909
Requested by: @tamld
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tamld/defense-in-depth/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
