### PR TITLE
docs(api): semver policy + v0-to-v1 migration guide (closes #34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,11 @@ These tools govern AI **while it reasons**. defense-in-depth governs AI **when i
 
 > All types across the roadmap (Layers 0–3 + Federation + Telemetry Sync) are ALREADY published in `src/core/types.ts` — compiled, documented, importable. Implementation follows incrementally per the gating contract in [`docs/vision/meta-growth-roadmap.md`](docs/vision/meta-growth-roadmap.md). See [`docs/vision/meta-architecture.md`](docs/vision/meta-architecture.md) for the full vision and types ledger.
 
+### Stability contract — v1.0 lane
+
+- [`docs/SEMVER.md`](docs/SEMVER.md) — what counts as Major / Minor / Patch on the four public surfaces (library entry point, Guard/Provider contracts, `defense.config.yml`, CLI), plus the deprecation timeline.
+- [`docs/migration/v0-to-v1.md`](docs/migration/v0-to-v1.md) — upgrade guide for anyone on `npm install defense-in-depth` without a version pin (currently `latest = v0.1.0`). Covers every feature shipped in v0.2 → v0.7-rc.1 and the recommended upgrade steps.
+
 ---
 
 ## 12. Contributing

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -1,0 +1,165 @@
+---
+id: DOC-SEMVER-POLICY
+status: active
+version: 1.0.0
+audience: library consumers, plugin authors, release managers, agents proposing API edits
+---
+
+> **Read this when**: You are upgrading `defense-in-depth`, authoring a custom guard or provider, or preparing a PR that touches a public surface (`src/index.ts`, the `Guard` contract, `defense.config.yml`, the CLI).
+> **Skip if**: You only need to configure or use the bundled guards and CLI defaults.
+> **Related**: [migration/v0-to-v1.md](migration/v0-to-v1.md) · [CHANGELOG.md](../CHANGELOG.md) · [`src/index.ts`](../src/index.ts) · [`src/core/types.ts`](../src/core/types.ts)
+
+# Semantic Versioning Policy
+
+> **TL;DR** — `defense-in-depth` follows [SemVer 2.0.0](https://semver.org/spec/v2.0.0.html) on **four** public surfaces: the library entry point (`src/index.ts`), the Guard / Provider contracts in `src/core/types.ts`, the `defense.config.yml` schema, and the `defense-in-depth` CLI. Anything not listed in §[Public Surface](#1-public-surface) is internal and may change in any release without a version bump.
+
+---
+
+## 1. Public Surface
+
+A change is governed by SemVer **only if** it observably affects one of the surfaces below. Everything else (tests, internal helpers, build tooling, governance docs, hint catalog content, internal JSONL record schemas) is non-API and can move freely.
+
+| Surface | Source of truth | What's covered |
+|:---|:---|:---|
+| **Library entry point** | [`src/index.ts`](../src/index.ts) | Every value-level export (`DefendEngine`, `Severity`, `EvidenceLevel`, `loadConfig`, `DEFAULT_CONFIG`, every `*Guard`, `allBuiltinGuards`, `createProvider`, `FileTicketProvider`, `HttpTicketProvider`) and every type-only export (`Guard`, `GuardContext`, `GuardResult`, `Finding`, `EngineVerdict`, `DefendConfig`, `TicketRef`, `Lesson`, `EvaluationScore`, `GuardF1Metric`, `DSPyConfig`, `FeedbackEvent`, `TicketStateProvider`, and every per-guard config interface). |
+| **Guard / Provider contract** | [`src/core/types.ts`](../src/core/types.ts) | `Guard`, `GuardContext`, `GuardResult`, `Finding`, `Severity`, `EvidenceLevel`, `EngineVerdict`, `TicketStateProvider`. Custom guards/providers implement these — changing their shape changes the world for every consumer. |
+| **Configuration schema** | `DefendConfig` in [`src/core/types.ts`](../src/core/types.ts), validated by [`src/core/config-loader.ts`](../src/core/config-loader.ts) | The `defense.config.yml` keys: `version`, `guards.*`, `hints?`, federation provider config. Adding a new optional key is Minor; renaming or removing a key is Major. |
+| **CLI surface** | [`src/cli/index.ts`](../src/cli/index.ts) and the binary `npx defense-in-depth …` | Subcommand names, documented flags, exit codes (`0` pass / `1` BLOCK / `2` config error), the contract that `WARN` does not change exit code, and the contract that DSPy/provider failures degrade to WARN, never crash. |
+
+**Out of scope** — these are *not* part of the public surface and may change in any release:
+
+- Anything reachable only via deep paths like `dist/core/dspy-client.js` that is **not** re-exported from `src/index.ts`. If consumers reach into `dist/...`, they're on the internal API and own the breakage.
+- Stderr formatting, log levels, ANSI colours, hint copy text, doctor banners.
+- The hint catalog (`H-001-no-dspy`, …) — IDs, trigger conditions, and copy may evolve. The hint *engine* contract (env-var opt-out, cooldown semantics, JSON state file shape) is stable.
+- Append-only JSONL record schemas under `.agents/records/` (`feedback.jsonl`, `lesson-recalls.jsonl`, `lesson-outcomes.jsonl`, `growth_metrics.jsonl`). They are evidence stores, not an integration contract.
+- The `.agents/` scaffold templates emitted by `init --scaffold`. Templates iterate; consumers can re-run scaffold or fork.
+- Anything under `templates/`, `tests/`, `scripts/`, `.github/`, `docs/`.
+
+> If you are unsure whether a change you're proposing is covered, ask: "Could a v0.7.x consumer that imports only from `defense-in-depth` (not `defense-in-depth/dist/...`) observe this change without re-running `npm install`?" If yes, it's covered. If no, it isn't.
+
+---
+
+## 2. Major (breaking) — `X.0.0`
+
+A bump to MAJOR means at least one of the following landed:
+
+### 2.1 Library exports
+
+- Removing or renaming any value-level export from `src/index.ts`.
+- Removing or renaming any type-only export from `src/index.ts`.
+- Narrowing an existing export's type in a way that breaks code that compiled against the prior version (e.g. making a previously optional field required, narrowing a union, tightening a generic constraint).
+- Moving a public symbol to a different deep import path so that prior `dist/...` deep imports stop resolving — but only if the symbol was *also* removed from the barrel. Deep-path-only consumers are not on the public surface (see §1).
+
+### 2.2 Guard / Provider contract
+
+- Adding a required member to `Guard`, `GuardContext`, `Finding`, `GuardResult`, `EngineVerdict`, or `TicketStateProvider` without a default — every existing third-party guard or provider must update to compile.
+- Renaming or removing a member of any of the contracts above.
+- Renaming a `Severity` value or `EvidenceLevel` enum member, or removing one.
+- Changing the engine's behavioural contract for guards in a way that breaks pure guards: e.g. removing the "guards never throw" engine-level catch, or changing pipeline semantics from collect-all to fail-fast (the inverse of the current [Fail-Fast Policy](dev-guide/fail-fast-policy.md)).
+
+### 2.3 Configuration schema
+
+- Renaming or removing any `defense.config.yml` key (`guards.hollowArtifact`, `guards.federation`, etc.).
+- Bumping the required `version:` field to a value that older configs no longer satisfy. The current required value is `"1"`; bumping it to `"2"` is a Major change.
+- Changing a default such that an unchanged config from a prior version produces a *different verdict* on the same input. Adding new patterns to a guard's default list that flag artifacts that previously passed counts here — even though the schema didn't change, the contract did.
+
+### 2.4 CLI surface
+
+- Renaming or removing a documented subcommand (`init`, `verify`, `doctor`, `eval`, `feedback`, `lesson`, `growth`).
+- Renaming or removing a documented flag.
+- Changing exit codes — the `0 / 1 / 2` contract is part of the CLI surface and is what scripts and CI runners depend on.
+- Dropping support for a Node.js version that was previously supported (current floor: Node ≥18 per `engines` in [`package.json`](../package.json) and the test matrix in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml)).
+
+### 2.5 Reasonable carve-outs
+
+A *security* fix that requires a breaking change is still a Major bump — but it is shipped under the deprecation timeline in §[Deprecation Policy](#5-deprecation-policy) only when a non-breaking mitigation is impossible. Otherwise, security fixes are released as Patch or Minor on the affected line(s).
+
+---
+
+## 3. Minor (feature) — `0.X.0`
+
+A bump to MINOR means at least one of the following landed and **no** Major condition applies:
+
+- A new built-in guard. The guard is registered in `guards/index.ts`, surfaced through `allBuiltinGuards`, and re-exported from `src/index.ts`. Existing configs continue to run unchanged because new guards default to `enabled: false` unless the consumer opts in.
+- A new optional key in `defense.config.yml` whose default preserves prior verdicts on prior input. Example: the `hints` block added in v0.7-rc.1 is opt-in (default `enabled: true` but earned-trigger only — fresh repos see nothing).
+- A new value-level or type-only export added to `src/index.ts`.
+- A new optional member added to a public type in `src/core/types.ts` (e.g. an additional optional field on `Lesson` or `TicketRef`).
+- A new CLI subcommand or a new flag on an existing subcommand whose absence preserves prior behaviour.
+- New `npm` dist-tags (e.g. `next` for release candidates) — adding a tag does not affect anyone on `latest`.
+
+> A new built-in guard turning **on by default** is a Major change, not a Minor one — it can change the verdict for unchanged input. New guards always ship `enabled: false` to stay Minor-safe.
+
+---
+
+## 4. Patch — `0.0.X`
+
+A bump to PATCH means none of the above changed, but at least one of the following did:
+
+- Bug fixes that restore documented behaviour. If a guard was *supposed* to flag a pattern but didn't because of a regex bug, fixing it is Patch — even though some consumer's previously-green commit will now flag. The pre-fix behaviour was a defect, not a contract.
+- Performance, internal refactoring, type-level cleanups that don't change emitted JS or `.d.ts` shape (the [PR #56 `Severity` re-export removal](https://github.com/tamld/defense-in-depth/pull/56) is the canonical example — verified zero callers, drops a dead barrel re-export, no Major bump).
+- Documentation, examples, README, CHANGELOG.
+- Test, CI, build-script, and tooling changes that don't ship in the npm tarball (the package's `files` field in `package.json` lists exactly what ships).
+- `dependencies` / `devDependencies` bumps that don't change the public surface. The runtime dependency floor (`yaml ^2.7.1`) is the only thing visible to consumers; a lock-only or devDeps-only bump is Patch.
+
+---
+
+## 5. Deprecation Policy
+
+Anything on the public surface (§1) MUST follow the deprecation lane below before it can be removed in a Major bump:
+
+1. **Mark with `@deprecated` JSDoc** on the export site in `src/index.ts` or `src/core/types.ts`. Include the replacement and the planned removal version. TypeDoc / language-server tooling surfaces this directly to consumers.
+2. **Emit `console.warn` on first use** when the deprecated symbol is reached at runtime — for value-level exports and CLI flags that have a runtime path. Once-per-process is enough; do not spam.
+3. **Document the deprecation** in `CHANGELOG.md` under a `### Deprecated` header in the release that introduced the marker, and link the replacement.
+4. **Wait at least one Minor cycle, AND at least 6 months of wall-clock time, AND across at least one rc/GA cut**, whichever is longest. This window is the consumer's grace period — long enough that anyone on a Tier-A LTS workflow gets at least one upgrade pass.
+5. **Remove only in a Major bump.** A Minor or Patch may not delete a deprecated symbol.
+
+A type-only export that has no runtime path can skip step 2; the JSDoc + CHANGELOG + grace window still apply.
+
+> **Why `console.warn`, not `throw`** — The whole project's design contract is "WARN, do not crash". Throwing on a deprecated call would be a breaking change masquerading as a warning. See the [DSPy fail-fast policy](dev-guide/fail-fast-policy.md) for the same shape applied to inference failures.
+
+---
+
+## 6. Pre-release Channels
+
+Two `npm` dist-tags are part of the published surface:
+
+- **`latest`** — only points at a stable GA release (no `-rc`, no `-beta`). This is what `npm install defense-in-depth` (no version pin) installs. Promoting a build to `latest` is a release-engineering act gated on the bake protocol in [`docs/vision/meta-growth-roadmap.md`](vision/meta-growth-roadmap.md).
+- **`next`** — release candidates and pre-release builds (`X.Y.Z-rc.N`, `X.Y.Z-beta.N`). Consumers opt in with `npm install defense-in-depth@next`. SemVer applies *within* the rc series: a breaking change between `1.0.0-rc.1` and `1.0.0-rc.2` is allowed because rc.1 is, by contract, not stable. SemVer applies *across* GA boundaries normally.
+
+Tags older than `next` (any historical alpha/canary) are not part of the contract and may be deleted at any time.
+
+---
+
+## 7. What This Policy is Not
+
+- It is not a freeze. The library is still actively developed; types in `src/core/types.ts` were designed up front so the *shape* is stable, but the implementations behind them ship incrementally per the roadmap.
+- It is not a substitute for tests. The smoke test added in [PR #56](https://github.com/tamld/defense-in-depth/pull/56) (`tests/public-api.test.js`) is the trip-wire that catches accidental drops from `src/index.ts` — without it, a future PR could remove a barrel export without anyone noticing until a consumer's CI breaks. Per-guard unit tests are the trip-wire for behavioural contract drift.
+- It is not opt-in. Every PR that touches the public surface is reviewed against this document, and CodeRabbit is configured (assertive profile, see [`.coderabbit.yaml`](../.coderabbit.yaml)) to flag drift.
+
+---
+
+## 8. Quick Decision Table
+
+| Change | Bump |
+|:---|:---|
+| Add a new optional field to `Lesson` | Minor |
+| Make an optional field on `Lesson` required | Major |
+| Add a new built-in guard, `enabled: false` by default | Minor |
+| Add a new built-in guard, `enabled: true` by default | Major |
+| Add a new value to `Severity` (e.g. `INFO`) | Major (existing exhaustive `switch` blocks break) |
+| Rename `EvidenceLevel.RUNTIME` to `EvidenceLevel.OBSERVED` | Major |
+| Drop a dead internal re-export with verified zero callers | Patch |
+| Tighten a regex in `hollowArtifact`'s default patterns | Major (verdict can change on unchanged input) |
+| Loosen the same regex to fix a false-positive | Patch (bug fix; restores documented intent) |
+| Add `--json` flag to `verify` | Minor |
+| Change `verify` exit code on WARN from `0` to `1` | Major |
+| Bump Node floor from 18 to 20 | Major |
+| Bump `yaml` peer-tolerated version range | Minor |
+| Rename hint `H-001-no-dspy` to `H-001-dspy-suggested` | Patch (hint catalog content is not on the public surface) |
+| Rename `defense.config.yml` key `guards.hollowArtifact` to `guards.artifactQuality` | Major |
+
+If your change isn't in the table and you're not sure, default to the higher bump and document the rationale in the PR — it is far cheaper to over-bump than to break a consumer.
+
+---
+
+> Executor: Devin

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,8 @@
 | Writing or registering a Guard | [dev-guide/writing-guards.md](dev-guide/writing-guards.md) | 10 min |
 | Connecting a DSPy inference provider | [dev-guide/dspy-providers.md](dev-guide/dspy-providers.md) | 8 min |
 | Understanding engine fail-fast behavior | [dev-guide/fail-fast-policy.md](dev-guide/fail-fast-policy.md) | 5 min |
+| Understanding what counts as breaking | [SEMVER.md](SEMVER.md) | 8 min |
+| Upgrading from v0.x to v1.0 | [migration/v0-to-v1.md](migration/v0-to-v1.md) | 12 min |
 | Understanding the project's threat model | [../SECURITY.md](../SECURITY.md) | 10 min |
 | Understanding long-term architecture | [vision/meta-architecture.md](vision/meta-architecture.md) | 15 min |
 | Understanding philosophy and roadmap | [../STRATEGY.md](../STRATEGY.md) | 15 min |
@@ -34,6 +36,13 @@
 | File | Purpose |
 |:---|:---|
 | [meta-architecture.md](vision/meta-architecture.md) | The 5-layer meta-memory model and long-term system vision |
+
+### Stability Contract (`docs/`)
+
+| File | Purpose |
+|:---|:---|
+| [SEMVER.md](SEMVER.md) | Public-surface inventory, Major/Minor/Patch decision rules, deprecation policy, pre-release channels |
+| [migration/v0-to-v1.md](migration/v0-to-v1.md) | Upgrade guide for v0.1.0 → v1.0 (covers every feature shipped in v0.2 → v0.7-rc.1) |
 
 ### Project Root
 

--- a/docs/migration/v0-to-v1.md
+++ b/docs/migration/v0-to-v1.md
@@ -1,0 +1,253 @@
+---
+id: DOC-MIGRATION-V0-TO-V1
+status: active
+version: 1.0.0
+audience: existing v0.1.0 → v0.7-rc.1 consumers, anyone on `npm install defense-in-depth` without a version pin
+---
+
+> **Read this when**: You installed `defense-in-depth` before `v1.0.0` (most likely v0.1.0, since that is the current `npm latest`) and want to upgrade to v1.0.
+> **Skip if**: You are on a fresh install — `npm install defense-in-depth` after the v1.0.0 GA cut already gives you the new surface; no migration needed.
+> **Related**: [SEMVER.md](../SEMVER.md) · [CHANGELOG.md](../../CHANGELOG.md) · [user-guide/configuration.md](../user-guide/configuration.md) · [user-guide/cli-reference.md](../user-guide/cli-reference.md)
+
+# Migration Guide — v0.x → v1.0
+
+> **TL;DR** — v1.0 is a stabilisation release, not a redesign. If your `defense.config.yml` declares `version: "1"` and you only consume the public surface (no `dist/...` deep imports), upgrading from any v0.x line is a one-line bump in `package.json`. Everything below is the long-form audit you should run if you are on **v0.1.0** specifically — the npm `latest` build that is roughly 20 days behind the development branch and missing every feature shipped in v0.2 → v0.7.
+
+---
+
+## 1. What v1.0 Is
+
+v1.0 freezes the public surface that has been incrementally landing since v0.2:
+
+| Surface | Frozen by v1.0 | Where to read it |
+|:---|:---|:---|
+| Library entry point | Every value- and type-level export from [`src/index.ts`](../../src/index.ts) | [SEMVER §1](../SEMVER.md#1-public-surface) |
+| Guard / Provider contract | `Guard`, `GuardContext`, `GuardResult`, `Finding`, `Severity`, `EvidenceLevel`, `EngineVerdict`, `TicketStateProvider` | [`src/core/types.ts`](../../src/core/types.ts) · [`.agents/contracts/guard-interface.md`](../../.agents/contracts/guard-interface.md) |
+| Configuration schema | `DefendConfig` (the `defense.config.yml` shape), required `version: "1"` field | [user-guide/configuration.md](../user-guide/configuration.md) |
+| CLI surface | `init`, `verify`, `doctor`, `eval`, `feedback`, `lesson`, `growth` subcommands · exit codes `0/1/2` · WARN ≠ exit non-zero | [user-guide/cli-reference.md](../user-guide/cli-reference.md) |
+
+After v1.0 GA, every change on these surfaces follows the bump rules in [SEMVER.md](../SEMVER.md).
+
+> **What v1.0 is NOT**: a new feature batch. The features were shipped in v0.2 through v0.7-rc.1; v1.0 is the act of saying "these are stable, you can depend on them". See the [release lifecycle umbrella](https://github.com/tamld/defense-in-depth/issues/42).
+
+---
+
+## 2. Breaking Changes in v1.0
+
+**There are no source-level breaking changes between the last v0.7-rc.1 and v1.0.0.** Every change required to land v1.0 was either additive or a no-behaviour-change refactor with verified zero callers.
+
+The two refactors landing in the v1.0 lane that *could* surprise a consumer who was reaching past the public surface:
+
+1. **`Severity` is no longer re-exported from `src/core/engine.ts`.** It is exported from `src/index.ts` (the barrel) and from `src/core/types.ts` (the SSoT). If you have an import like `import { Severity } from "defense-in-depth/dist/core/engine.js"`, switch it to `import { Severity } from "defense-in-depth"`. See [PR #56](https://github.com/tamld/defense-in-depth/pull/56) for the zero-caller audit and rationale.
+2. **`defense.config.yml` requires `version: "1"`.** The field has been required since v0.1; v1.0 keeps it as `"1"`. If you are migrating from an *internal-fork pre-v0.1 build* that had no `version:` field, add `version: "1"` at the top of the file. Public v0.1.0 already requires this, so npm-installed consumers are not affected.
+
+If your install is anywhere between v0.1.0 and v0.7-rc.1, v1.0 itself adds nothing breaking. The reason this guide is long is that **v0.1.0 → v1.0 spans every feature shipped in v0.2 → v0.7-rc.1**, and you should know what landed before you upgrade.
+
+---
+
+## 3. What You Get When You Upgrade From v0.1.0
+
+The npm `latest` tag has pointed at v0.1.0 since 2026-04-07. The development branch has shipped six minor lines since then. Here is what becomes available in your `node_modules` the moment you upgrade.
+
+### 3.1 v0.2 — `.agents/` ecosystem scaffold
+
+- `npx defense-in-depth init --scaffold` creates the `.agents/` governance ecosystem alongside the hooks: rules, workflows, skills, contracts, philosophy.
+- The base `init` (no flag) is unchanged from v0.1: it installs hooks and writes `defense.config.yml`. Scaffold is opt-in.
+
+### 3.2 v0.3 — File-based ticket federation
+
+- New `ticketIdentity` guard (default WARN severity, opt-in via `guards.ticketIdentity.enabled: true`). Detects cross-ticket contamination in commits using a configurable TKID regex.
+- New `TicketRef` type and `TicketStateProvider` interface in `src/core/types.ts`.
+- New `FileTicketProvider` — reads `TICKET.md` YAML frontmatter; zero infrastructure required.
+- `extractTicketRef()` derives ticket scope generically from branch / commit / dirname; no AAOS lock-in.
+
+### 3.3 v0.4 — Memory layer
+
+- `lessons.jsonl` — local case-law store; no external infrastructure.
+- New `did lesson` CLI subcommand — record and search past lessons (`wrongApproach` + `correctApproach` schema).
+- New `did growth` CLI subcommand — record `GrowthMetric` observations to `growth_metrics.jsonl`.
+- New `Lesson` and `GrowthMetric` types exported from `src/core/types.ts`.
+
+### 3.4 v0.5 — Optional DSPy semantic layer
+
+- `hollowArtifact` guard gains an `useDspy` opt-in (default `false`). When on, the guard's three-layer chain (regex → length heuristic → DSPy) augments deterministic checks with semantic scoring. **DSPy never BLOCKs**; it only raises WARN. Failures degrade silently per the [Fail-Fast Policy](../dev-guide/fail-fast-policy.md).
+- New `did eval` standalone CLI subcommand for artifact quality analysis with DSPy.
+- New `EvaluationScore` and `DSPyConfig` types.
+- See [user-guide/configuration.md](../user-guide/configuration.md) and [dev-guide/dspy-providers.md](../dev-guide/dspy-providers.md) for endpoint setup (Ollama, Groq, NVIDIA NIM, OpenRouter, Gemini Flash all documented).
+
+### 3.5 v0.6 — Federation guards
+
+- New `federationGuard` — pure cross-validation of child execution against parent ticket lifecycle phase. Zero I/O in the guard itself; parent state resolved by the engine's enrichment phase.
+- New `HttpTicketProvider` — `globalThis.fetch` with `AbortController` timeout; non-fatal on failure.
+- New `FederationGuardConfig` config block; default `enabled: false`.
+- `TicketRef` extended with `parentId`, `parentPhase`, `authorized`. The fields are optional, so existing `TicketRef` consumers compile unchanged.
+
+### 3.6 v0.6.x — Operational hardening
+
+- Server-side composite action (`.github/actions/verify/action.yml`) — runs the same guard pipeline against the PR diff in CI. Closes the bypass via `git commit --no-verify`. See [README §3](../../README.md) for the recommended GitHub Actions wiring.
+- Release workflow — tag `v*.*.*` triggers build → test → npm publish (with provenance) → GitHub Release. v0.1.0 ↔ development gap that this guide exists to close was a direct consequence of the absence of this workflow before v0.6.
+- `SECURITY.md` — explicit threat model for v0.5+ outbound network calls (`hollowArtifact.useDspy`, `HttpTicketProvider`, `federation.parentEndpoint`).
+
+### 3.7 v0.7-rc.1 — Memory loop + Progressive Discovery
+
+- **`did feedback`** — first-class CLI for labelling guard findings as TP/FP/FN/TN. Append-only `.agents/records/feedback.jsonl`; deterministic event ids. Foundation for the F1 measurement that is gated behind Track A4 exit per [`docs/vision/meta-growth-roadmap.md`](../vision/meta-growth-roadmap.md).
+- **`did lesson outcome`** + **`did lesson scan-outcomes`** — record explicit recall outcomes; walk git diffs for implicit re-occurrences via `Lesson.wrongApproachPattern` regex matches.
+- **`did doctor --hints`** + earned-trigger hint engine — non-blocking discovery surface for v0.4+ features. Three-layer anti-nag (earned trigger, 7-day cooldown, `NO_HINTS=1` / `CI=true` / `hints.enabled: false`). Fresh repos see zero hints.
+- New optional `hints` block in `defense.config.yml`. The minimal config template emitted by `init` ships this block so users discover the knobs.
+- New types: `Hint`, `HintState`, `LessonOutcome`, `RecallEvent`, `RecallMetric`, `FeedbackEvent`, `GuardF1Metric`.
+
+### 3.8 v0.7 → v1.0
+
+- Two missing built-in guards (`rootPollutionGuard`, `hitlReviewGuard`) and a long list of public types are added to the `src/index.ts` barrel ([PR #56](https://github.com/tamld/defense-in-depth/pull/56), closes [#33](https://github.com/tamld/defense-in-depth/issues/33)). v0.1.0 consumers had to reach into deep `dist/...` paths for these; v1.0 lifts them into the canonical entry point.
+- Dead `Severity` re-export from `src/core/engine.ts` is dropped (same PR; verified zero callers).
+- This document and [SEMVER.md](../SEMVER.md) ship as the stability contract for the v1.0 surface.
+
+---
+
+## 4. Configuration Migration
+
+Every config file declares its own version. The current contract:
+
+```yaml
+version: "1"
+guards:
+  hollowArtifact:
+    enabled: true
+  ssotPollution:
+    enabled: true
+  # … other guards default to disabled
+```
+
+The `version: "1"` field has been required since v0.1.0. If you have a config without it (only possible if you forked from a pre-v0.1 internal build), add it.
+
+### 4.1 New config blocks available since v0.1.0
+
+If your config was hand-written against the v0.1 schema, the following blocks are *available* but optional. None of them is required to keep your existing setup working.
+
+| Block | Since | Default if absent | What you get by enabling |
+|:---|:---|:---|:---|
+| `guards.rootPollution` | v0.1 | disabled | Blocks files in repo root that aren't on the allow-list. |
+| `guards.commitFormat` | v0.1 | disabled | Conventional Commits enforcement. |
+| `guards.branchNaming` | v0.1 | disabled | Regex-validated branch names. |
+| `guards.phaseGate` | v0.1 | disabled | Forces a planning artifact (e.g. `PLAN.md`) before source commits. |
+| `guards.hitlReview` | v0.1 | disabled | Blocks direct commits on protected branches; forces PR workflow. |
+| `guards.ticketIdentity` | v0.3 | disabled | Cross-ticket contamination detection (WARN by default). |
+| `guards.hollowArtifact.useDspy` | v0.5 | `false` | Tier-3 semantic evaluation (opt-in). |
+| `guards.federation` | v0.6 | disabled | Parent↔child ticket lifecycle governance. |
+| `hints` | v0.7-rc.1 | implicit defaults | Earned-trigger discovery hints in `did doctor` / `did verify` output. |
+
+Run `npx defense-in-depth init` in a *temporary* directory to see the latest config template; copy the blocks you want.
+
+### 4.2 No-op upgrade path
+
+If your `defense.config.yml` only declares the v0.1 guards (`hollowArtifact`, `ssotPollution`) with `enabled: true` and nothing else, **the file works unchanged on v1.0**. You inherit every new guard with `enabled: false` defaults. No verdict on existing input changes.
+
+---
+
+## 5. CLI Migration
+
+Your existing v0.1.0 CLI invocations all keep working:
+
+```bash
+npx defense-in-depth init
+npx defense-in-depth verify
+npx defense-in-depth doctor
+```
+
+The exit code contract is unchanged: `0` on pass, `1` on BLOCK, `2` on config error. WARN does not change exit code.
+
+New subcommands available since v0.1:
+
+| Command | Since | Purpose |
+|:---|:---|:---|
+| `npx defense-in-depth eval <files...>` | v0.5 | Standalone DSPy artifact quality scoring. |
+| `npx defense-in-depth feedback ...` | v0.7-rc.1 | TP/FP/FN/TN labelling for guard findings. |
+| `npx defense-in-depth lesson ...` | v0.4 (record/search), v0.7-rc.1 (outcome / scan-outcomes) | Local case-law store. |
+| `npx defense-in-depth growth ...` | v0.4 | Growth metric capture. |
+| `npx defense-in-depth doctor --hints` | v0.7-rc.1 | Inspect / dismiss / reset earned discovery hints. |
+
+See [user-guide/cli-reference.md](../user-guide/cli-reference.md) for the full surface and flag inventory.
+
+---
+
+## 6. Programmatic API Migration
+
+If you embed `defense-in-depth` as a library:
+
+### 6.1 Imports — prefer the barrel, drop deep paths
+
+```ts
+// ✓ Recommended (works on every version since the symbol was added)
+import {
+  DefendEngine,
+  loadConfig,
+  Severity,
+  EvidenceLevel,
+  rootPollutionGuard,
+  hitlReviewGuard,
+  federationGuard,
+  allBuiltinGuards,
+} from "defense-in-depth";
+
+// ✓ Type imports likewise come from the barrel
+import type {
+  Guard,
+  GuardContext,
+  GuardResult,
+  Finding,
+  EngineVerdict,
+  DefendConfig,
+  TicketRef,
+  Lesson,
+  EvaluationScore,
+  GuardF1Metric,
+  DSPyConfig,
+  FeedbackEvent,
+  TicketStateProvider,
+} from "defense-in-depth";
+
+// ✗ Avoid (deep paths into compiled output)
+import { Severity } from "defense-in-depth/dist/core/engine.js";
+```
+
+The deep-path import on the last line worked in v0.1 → v0.7-rc.0 by accident — `engine.ts` carried a tail re-export of `Severity` that turned out to have zero internal callers. v1.0 drops it (see [PR #56](https://github.com/tamld/defense-in-depth/pull/56)). Switch to the barrel.
+
+### 6.2 Custom guard authors
+
+The `Guard` interface has been stable since v0.1. The `GuardContext.semanticEvals` field landed in v0.5 as **optional**, so existing v0.1 guards still compile. If you want to read precomputed DSPy scores from the engine's enrichment phase, add an `if (ctx.semanticEvals?.dspy) { … }` check — the field is opt-in and may be undefined.
+
+### 6.3 Custom provider authors
+
+`TicketStateProvider` has been stable since v0.3. v0.6 adds optional `parentId`, `parentPhase`, `authorized` fields to `TicketRef`; if your provider can resolve a parent, populate them. Otherwise, return what you have — the federation guard tolerates partial state.
+
+---
+
+## 7. Recommended Upgrade Steps
+
+The path that minimises surprises:
+
+1. **Pin to your current version first** so you can roll back. `npm install defense-in-depth@0.1.0 --save-exact`. Commit `package.json` + `package-lock.json`. This is your safety net.
+2. **Read the [CHANGELOG](../../CHANGELOG.md) entries between your version and v1.0.** It is the canonical list of what landed. This guide is an interpretation; the CHANGELOG is the source.
+3. **Bump.** `npm install defense-in-depth@^1.0.0`. The `^` floor is fine — every subsequent v1.x is non-breaking by [SEMVER.md](../SEMVER.md).
+4. **Re-run `npx defense-in-depth doctor`.** It prints any config drift, missing hooks, and (since v0.7-rc.1) any earned discovery hints. Fix what it reports. The doctor is idempotent.
+5. **Run your test suite or `npx defense-in-depth verify --files <staged>` against a representative commit.** Confirm no verdict changed unexpectedly. v1.0 is contract-stable, so this is paranoia, not necessity — but paranoia is cheap.
+6. **Optional: enable the new guards.** Add `guards.rootPollution.enabled: true`, `guards.hitlReview.enabled: true`, `guards.federation.enabled: true`, `guards.hollowArtifact.useDspy: true` selectively. Each is independent; enable in the order that gives you the most value first.
+7. **Optional: enable the server-side action.** If you maintain a CI pipeline, wire in `.github/actions/verify` per [README §3](../../README.md). Client-side hooks are bypassable via `git commit --no-verify`; the server-side action is the only thing that gives HITL claims real teeth.
+
+---
+
+## 8. Rollback Plan
+
+If v1.0 breaks something for you, the rollback is one command:
+
+```bash
+npm install defense-in-depth@0.7 --save-exact
+```
+
+`v0.7-rc.1` is the last pre-v1.0 build. It is functionally a superset of every prior public release except for the [PR #56](https://github.com/tamld/defense-in-depth/pull/56) deep-path `Severity` re-export, which is the one thing v1.0 removes that v0.7 keeps. If your code depends on that exact deep import path, pinning to `0.7` is the workaround until you can update the import.
+
+If you find a real v0.x → v1.0 break that this guide didn't predict, please open an issue with the diff that surprised you. The [SEMVER policy](../SEMVER.md) is the contract; a real break is a contract violation that should be tracked.
+
+---
+
+> Executor: Devin


### PR DESCRIPTION
## Description

Closes #34 — adds the v1.0 stability contract docs and links them from the README + docs index.

Two new docs land in this PR. Both follow the existing `docs/dev-guide/*` style: YAML frontmatter, lazy-load header (`Read this when` / `Skip if` / `Related`), TL;DR, numbered sections.

### `docs/SEMVER.md` — Semver Policy

- §1 **Public Surface** — names the four surfaces SemVer governs: `src/index.ts` (every value- and type-only export), the `Guard` / `TicketStateProvider` contracts in `src/core/types.ts`, the `defense.config.yml` schema, and the CLI (subcommands + exit codes `0/1/2`).
- §2 **Major** — the breaking-change inventory: removing/renaming exports, narrowing types, mutating the Guard/Provider contract, renaming `Severity`/`EvidenceLevel` values, renaming/removing `defense.config.yml` keys, changing defaults that flip verdicts on unchanged input, renaming/removing CLI subcommands or flags, exit-code changes, dropping a Node version.
- §3 **Minor** — new built-in guards (must default to `enabled: false` to stay non-breaking), new optional config keys, new exports, new CLI surface.
- §4 **Patch** — bug fixes that restore documented behaviour, internal refactors with verified zero callers ([PR #56](https://github.com/tamld/defense-in-depth/pull/56) is the canonical example).
- §5 **Deprecation Policy** — `@deprecated` JSDoc + `console.warn` on first use + CHANGELOG entry + minimum 6-month grace window across at least one Minor cycle and one rc/GA cut, removal only on Major.
- §6 **Pre-release Channels** — the `latest` vs `next` npm dist-tag contract.
- §7 **What this is not** — explicit non-claims (not a freeze, not opt-in, not a substitute for tests).
- §8 **Quick Decision Table** — 14 worked rows covering the cases reviewers will actually need.

### `docs/migration/v0-to-v1.md` — Migration Guide

- §1 **What v1.0 is** — the four frozen surfaces, with cross-links.
- §2 **Breaking changes** — there are none at the source level. The two surprises are documented: deep-path `Severity` import (PR #56) and the long-required `version: "1"` field.
- §3 **What you get when you upgrade from v0.1.0** — full feature inventory shipped between v0.2 → v0.7-rc.1, version by version: `.agents/` scaffold, file-based federation, memory layer (lessons + growth), DSPy semantic eval, federation guard + HttpTicketProvider, server-side composite action, hints + feedback + lesson-outcome.
- §4 **Configuration migration** — what's available, what's required, the no-op upgrade path for minimal v0.1 configs.
- §5 **CLI migration** — every existing v0.1 invocation still works; new subcommands listed (`eval`, `feedback`, `lesson outcome`, `lesson scan-outcomes`, `growth`, `doctor --hints`).
- §6 **Programmatic API migration** — recommends the barrel; includes a copy-paste import block; calls out the deep-path import that v1.0 drops.
- §7 **Recommended upgrade steps** — pin → read CHANGELOG → bump → `doctor` → verify → opt in to new guards → wire server-side action.
- §8 **Rollback plan** — `npm install defense-in-depth@0.7 --save-exact` is the documented rollback.

### README + docs index

- New `### Stability contract — v1.0 lane` subsection inside README §11 (Roadmap), linking both docs.
- Two new rows in `docs/index.md`'s "When to Read What" table, plus a new "Stability Contract (`docs/`)" subsection in the document map.

Fixes #34

## Type of Change

- [ ] 🐛 Bug fix (non-breaking)
- [ ] ✨ New feature (non-breaking)
- [ ] 🛡️ New guard
- [ ] 💥 Breaking change
- [x] 📝 Documentation only
- [ ] 🔧 Refactor (no behavior change)

## Checklist

- [x] My code follows the [consistency rules](.agents/rules/rule-consistency.md)
- [x] I used conventional commit format for the PR title
- [x] I added tests for new functionality — N/A (docs only)
- [x] All existing tests pass (`npm test`)
- [x] I updated documentation (README, CHANGELOG) if needed — README + `docs/index.md` updated; CHANGELOG entry will land with the v1.0 cut, not in this PR (the docs ship pre-GA so the deprecation lane and migration steps are visible to anyone tracking `main` or `next`).
- [x] New guards implement the `Guard` interface from `core/types.ts` — N/A
- [x] No `any` types used — N/A (no source changes)
- [x] No new external dependencies added

## For New Guards Only

N/A — documentation-only PR. No new guards.

## Evidence

`[CODE]` Direct edits / additions:

| File | Status | Lines |
|:---|:---|:---|
| `docs/SEMVER.md` | new | 165 |
| `docs/migration/v0-to-v1.md` | new | 253 |
| `docs/index.md` | modified | +9 |
| `README.md` | modified | +5 |

`[RUNTIME]` Local validation on `Node 22.20.0`, branch `feat/devin-1777334595-semver-migration-v1`:

```
$ npm ci
added 1 package, and audited 2 packages in <1s
found 0 vulnerabilities

$ npm run build
> defense-in-depth@0.7.0-rc.1 build
> tsc
[exit 0]

$ npm run lint
> defense-in-depth@0.7.0-rc.1 lint
> tsc --noEmit
[exit 0]

$ npm test
> defense-in-depth@0.7.0-rc.1 test
> node --test
…
ℹ tests 366
ℹ pass 366
ℹ fail 0
ℹ duration_ms <wall>
[exit 0]
```

`[CODE]` Public-surface footprint of this PR: zero. No file under `src/`, `tests/`, `templates/`, `.github/`, or any root config was touched. The PR is `docs/` + two README link blocks.

`[INFER]` This PR completes the docs-side of the v1.0 release lifecycle ([umbrella #42](https://github.com/tamld/defense-in-depth/issues/42)). The remaining items toward `v1.0.0-rc.1` are release-engineering (npm publish workflow, CHANGELOG cut, `version:` bump) and are tracked separately.

## Out-of-scope finding (separate ticket recommended)

While running `verify --files docs/SEMVER.md` against the repo's own docs to sanity-check, the `hollowArtifact` guard reported a finding because the `DEFAULT_CONFIG.guards.hollowArtifact.patterns` array in `src/core/config-loader.ts:21–28` ships **unescaped** strings (`"[Insert Here]"`, `"<Empty>"`) that get compiled as `new RegExp(p, "i")` in `src/guards/hollow-artifact.ts:77`. The `[…]` becomes a character class, so `[Insert Here]` ends up matching any letter `I`, `n`, `s`, `e`, `r`, `t`, ` `, `H` — virtually every English doc trips it. The "real" defaults in `DEFAULT_HOLLOW_PATTERNS` (`hollow-artifact.ts:25–33`) use proper anchored regexes (`/\[Insert\s*Here\]/i`), so this only affects users of the loaded `defense.config.yml` defaults. CI is unaffected because the existing self-verify is a smoke test, not a diff scan.

This is genuinely a guard bug, not a docs bug — the v1.0 SEMVER policy added in this PR classifies it as **Patch** under §4 ("bug fixes that restore documented behaviour"). I'll open a separate issue for the fix unless you'd prefer it folded in here.

Link to Devin session: https://app.devin.ai/sessions/8db2c99daa344211a783529bd088be68
Requested by: @tamld
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tamld/defense-in-depth/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
