### PR TITLE
docs(agents): reconcile .agents/AGENTS.md ecosystem map with disk (closes #53)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -18,7 +18,7 @@ through 5 phases:
 ```mermaid
 flowchart TD
     A["🤖 Agent enters project"] --> P1["① IDENTIFY\nRead AGENTS.md, detect platform"]
-    P1 --> P2["② DISCOVER\nRead all 11 rules + COGNITIVE_TREE"]
+    P1 --> P2["② DISCOVER\nRead all 20 rules + COGNITIVE_TREE"]
     P2 --> P3["③ SCAFFOLD\nCheck/create required artifacts"]
     P3 --> P4["④ CONTRIBUTE\nLearn evidence tags, lesson schema"]
     P4 --> P5["⑤ VERIFY\nRun defense-in-depth doctor"]
@@ -37,9 +37,9 @@ flowchart TD
 ```
 .agents/
 ├── AGENTS.md                  ← YOU ARE HERE
-├── philosophy/                # System mindset
+├── philosophy/                # System mindset (1 total)
 │   └── COGNITIVE_TREE.md      (3 branches + HITL trunk)
-├── rules/                     # Immutable project standards (19 total)
+├── rules/                     # Immutable project standards (20 total)
 │   ├── rule-consistency.md           (project standards)
 │   ├── rule-guard-lifecycle.md       (guard maturity)
 │   ├── rule-contribution-workflow.md (how to contribute)
@@ -48,19 +48,24 @@ flowchart TD
 │   ├── rule-lesson-quality.md        (specificity gate)
 │   ├── rule-zero-theater.md          (substance mandate)
 │   ├── rule-adaptive-language.md     (language policy)
+│   ├── rule-translation-glossary.md  (canonical bilingual terms)
 │   ├── rule-anti-yes-man.md          (brainstorm mandate)
 │   ├── rule-agent-workspace.md       (workspace zones)
 │   ├── rule-security-continuity.md   (fortress mandate)
 │   ├── rule-git-governance.md        (version control)
+│   ├── rule-coderabbit-integration.md (PR review bot contract)
 │   ├── rule-living-document.md       (anti-staleness)
 │   ├── rule-cross-platform.md        (OS compatibility)
 │   ├── rule-context-discipline.md    (context hygiene)
 │   ├── rule-document-budget.md       (doc size limits)
 │   ├── rule-flowchart-mandate.md     (visual compliance)
 │   └── rule-file-type-contract.md    (format selection)
-├── workflows/                 # Operational procedures
-│   └── procedure-task-execution.md
-├── skills/                    # Agent capabilities
+├── workflows/                 # Operational procedures (2 total)
+│   ├── procedure-task-execution.md         (task lifecycle)
+│   └── procedure-multi-agent-coordination.md (cross-agent handoffs)
+├── skills/                    # Agent capabilities (13 total + meta)
+│   ├── AGENTS.md              (skill-index router for agents)
+│   ├── SKILL_STANDARDS.md     (frontmatter + structure contract)
 │   ├── skill-bootstrap-agent/
 │   │   └── SKILL.md           (5-phase onboarding wizard)
 │   ├── skill-creator/
@@ -71,12 +76,27 @@ flowchart TD
 │   │   └── SKILL.md           (research pipeline with cross-check)
 │   ├── skill-impact-predictor/
 │   │   └── SKILL.md           (pre-implementation blast-radius analysis)
+│   ├── skill-review-code/
+│   │   └── SKILL.md           (PR-level governance review)
+│   ├── skill-threat-modeling-expert/
+│   │   └── SKILL.md           (adversary-first threat coverage)
+│   ├── skill-guard-governance/
+│   │   └── SKILL.md           (canonical guard design / impl / register)
+│   ├── skill-surgical-refactorer/
+│   │   └── SKILL.md           (minimum-blast guard refactors)
+│   ├── skill-test-architect/
+│   │   └── SKILL.md           (adversarial test-suite design)
+│   ├── skill-ai-dspy-validator/
+│   │   └── SKILL.md           (DSPy integration quality / WARN-not-BLOCK)
+│   ├── skill-devops-github-actions/
+│   │   └── SKILL.md           (CI/CD workflow authoring)
 │   └── _template/
 │       └── SKILL.md
-├── config/                    # Machine-readable configs
+├── config/                    # Machine-readable configs (1 total)
 │   └── guards.yml
-└── contracts/                 # Interface contracts
-    └── guard-interface.md
+└── contracts/                 # Interface contracts (2 total)
+    ├── guard-interface.md     (Guard / Provider contract)
+    └── jules.md               (Jules async-builder contract)
 ```
 
 ---


### PR DESCRIPTION
## Description

Closes #53 — brings the ecosystem-map block in `.agents/AGENTS.md` back in sync with what is actually on disk under `.agents/{skills,rules,workflows,contracts,philosophy,config}/`.

[`rule-living-document.md`](.agents/rules/rule-living-document.md) mandates **"all projections same commit"** — when a skill / rule / workflow is added, every map referring to it MUST update in the same commit. PR #51 patched the entry for the newly added `skill-impact-predictor` surgically and intentionally left the pre-existing drift untouched. This PR is the agreed follow-up.

Single-file change. Markdown only. No source touched.

Fixes #53

### Files added / removed in the map

`[CODE]` Direct edits inside the `## Ecosystem Map` block plus a one-token fix in the bootstrap mermaid diagram.

| Section | Before | After | Δ |
|:---|:---|:---|:---|
| `philosophy/` header | (no count) | `(1 total)` | +explicit count |
| `rules/` header | `(19 total)` | `(20 total)` | +1 (off-by-one fixed) |
| `rules/` listing | 18 entries | 20 entries | +`rule-translation-glossary.md`, +`rule-coderabbit-integration.md` |
| `workflows/` header | (no count) | `(2 total)` | +explicit count |
| `workflows/` listing | 1 entry | 2 entries | +`procedure-multi-agent-coordination.md` |
| `skills/` header | (no count) | `(13 total + meta)` | +explicit count |
| `skills/` listing | 6 entries | 13 entries + 2 meta files | +`skill-review-code/`, +`skill-threat-modeling-expert/`, +`skill-guard-governance/`, +`skill-surgical-refactorer/`, +`skill-test-architect/`, +`skill-ai-dspy-validator/`, +`skill-devops-github-actions/`. Also surfaces `skills/AGENTS.md` and `skills/SKILL_STANDARDS.md` at the top of the skills subtree. |
| `config/` header | (no count) | `(1 total)` | +explicit count |
| `contracts/` header | (no count) | `(2 total)` | +explicit count |
| `contracts/` listing | 1 entry | 2 entries | +`jules.md` |
| Bootstrap mermaid | `Read all 11 rules + COGNITIVE_TREE` | `Read all 20 rules + COGNITIVE_TREE` | rules-count drift in a sibling projection — fixed in the same commit per the living-document mandate |

New rule entries are placed in their topical neighbourhoods rather than appended at the bottom: `rule-translation-glossary.md` next to `rule-adaptive-language.md` (language family), `rule-coderabbit-integration.md` next to `rule-git-governance.md` (CI/SCM family).

New skill entries are grouped by purpose (research / review / threat → implementation / refactor / test → infra & integrations) so the listing reads like a capability map, not just an alphabetical dump. `_template/` stays last.

### Acceptance criteria (from #53)

- [x] Every actual file under `.agents/{skills,rules,workflows,contracts,philosophy,config}/` has a corresponding entry in the ecosystem-map tree block.
- [x] The "(N total)" counts in section headers match `ls -1 | wc -l` for each directory.
- [x] No entry in the map points at a path that does not exist on disk (no zombie entries).
- [x] PR description explicitly lists every file added/removed in the map (table above).
- [ ] CI green — running.

### Out of scope (per #53)

- No actual files added or removed under `.agents/`.
- No `SKILL_STANDARDS.md` content change.
- No edits to skills' `SKILL.md` frontmatter.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking)
- [ ] ✨ New feature (non-breaking)
- [ ] 🛡️ New guard
- [ ] 💥 Breaking change
- [x] 📝 Documentation only
- [ ] 🔧 Refactor (no behavior change)

## Checklist

- [x] My code follows the [consistency rules](.agents/rules/rule-consistency.md)
- [x] I used conventional commit format for the PR title
- [x] I added tests for new functionality — N/A (docs only)
- [x] All existing tests pass (`npm test`) — 392/392, unchanged
- [x] I updated documentation (README, CHANGELOG) if needed — this PR IS the doc update
- [x] New guards implement the `Guard` interface — N/A
- [x] No `any` types used — N/A
- [x] No new external dependencies added

## For New Guards Only

N/A — documentation-only PR, no source change.

## Evidence

`[RUNTIME]` Disk-vs-map count parity, run on the post-edit branch:

```
$ ls -1 .agents/rules/      | wc -l   # 20  → map shows '(20 total)'
$ find .agents/skills/ -mindepth 1 -maxdepth 1 -type d | wc -l   # 13 → map shows '(13 total + meta)'
$ ls -1 .agents/workflows/  | wc -l   # 2   → map shows '(2 total)'
$ ls -1 .agents/contracts/  | wc -l   # 2   → map shows '(2 total)'
$ ls -1 .agents/philosophy/ | wc -l   # 1   → map shows '(1 total)'
$ ls -1 .agents/config/     | wc -l   # 1   → map shows '(1 total)'
```

`[RUNTIME]` Zombie scan — every basename appearing as a tree entry in `.agents/AGENTS.md` was checked against `find .agents -name <basename>`:

```
ZOMBIE: (none)
```

`[RUNTIME]` Smoke run of the existing test suite:

```
$ npm test
…
ℹ tests 392
ℹ pass 392
ℹ fail 0
```

`[INFER]` Note on the ssotPollution guard: when `npx defense-in-depth verify --files .agents/AGENTS.md` is run locally on this branch, the guard correctly reports a BLOCK (the `.agents/**` pattern is protected). This is the intended behaviour — only humans (or human-instructed agents) may modify governance files. CI's `npx defense-in-depth verify` step has no staged files in the checkout (it's a smoke test, not a diff-based verify) so it does not fire on this PR. The HITL approval for this PR is recorded in issue #53 itself, which explicitly tasks an agent with this exact reconcile.

Executor: Devin

Link to Devin session: https://app.devin.ai/sessions/8db2c99daa344211a783529bd088be68
Requested by: @tamld
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tamld/defense-in-depth/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
