### PR TITLE
test(api): public-API & CLI exit-code contract tests (closes #35)

### DIFF
--- a/tests/contract/cli-exit-codes.test.js
+++ b/tests/contract/cli-exit-codes.test.js
@@ -1,0 +1,209 @@
+/**
+ * CLI exit-code CONTRACT tests (issue #35).
+ *
+ * ────────────────────────────────────────────────────────────────────
+ * Breaking any test in this file = SEMVER MAJOR bump per
+ * docs/SEMVER.md §3 (CLI is one of the four public surfaces).
+ * Git hooks, CI scripts, husky pipelines, and Lefthook configs all
+ * branch on these exit codes — silently changing them breaks every
+ * downstream automation that calls `defense-in-depth` from a shell.
+ * ────────────────────────────────────────────────────────────────────
+ *
+ * Scope (deliberately complementary to `tests/cli-ground-truth.test.js`):
+ *
+ *   cli-ground-truth.test.js → broad behavioural coverage of `verify`
+ *                               under many config / file shapes.
+ *   cli-exit-codes.test.js   → the THIN exit-code contract that hook
+ *                               authors and CI consumers depend on.
+ *
+ * The contract pinned here covers all top-level commands, not just
+ * `verify`, and frames each assertion as "the v1.0 process-level
+ * promise". Adding new commands is additive (Minor); changing an
+ * existing exit code is breaking (Major).
+ *
+ * Executor: Devin
+ */
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const CLI_PATH = path.join(REPO_ROOT, "dist", "cli", "index.js");
+
+let tmp;
+
+before(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "did-cli-contract-"));
+});
+
+after(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function runCli(args, cwd = tmp) {
+  return spawnSync(process.execPath, [CLI_PATH, ...args], {
+    cwd,
+    encoding: "utf-8",
+    env: { ...process.env, NO_COLOR: "1", CI: "true" },
+  });
+}
+
+function freshGitRepo(name) {
+  const root = path.join(tmp, name);
+  fs.mkdirSync(root, { recursive: true });
+  spawnSync("git", ["init", "-q"], { cwd: root });
+  // Local identity so future `git commit` inside the fixture (if any)
+  // never blocks on global config in CI runners.
+  spawnSync("git", ["config", "user.email", "did-contract@example.test"], { cwd: root });
+  spawnSync("git", ["config", "user.name", "did-contract"], { cwd: root });
+  return root;
+}
+
+// ─── Section 1: meta commands (always 0 / always 1) ──────────────────
+
+describe("CONTRACT — meta-command exit codes (CLI, issue #35)", () => {
+  it("`--version` exits 0 (consumed by version pinning scripts)", () => {
+    // Breaking this = MAJOR. Tools like Renovate / Dependabot scripts
+    // probe `defense-in-depth --version` to confirm a successful install.
+    const r = runCli(["--version"]);
+    assert.equal(r.status, 0, `stdout=${r.stdout}\nstderr=${r.stderr}`);
+    // Also pin the output shape: a semver-ish line MUST be on stdout.
+    assert.match(
+      r.stdout,
+      /\d+\.\d+\.\d+(?:[-.+][\w.-]+)?/,
+      "--version stdout must contain a semver-ish version string",
+    );
+  });
+
+  it("`-v` is a stable shorthand for `--version` and exits 0", () => {
+    const r = runCli(["-v"]);
+    assert.equal(r.status, 0);
+  });
+
+  it("`--help` exits 0 (every shell-completion / man-page renderer relies on this)", () => {
+    const r = runCli(["--help"]);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /Usage:/i, "--help stdout must contain a Usage banner");
+  });
+
+  it("`-h` is a stable shorthand for `--help` and exits 0", () => {
+    const r = runCli(["-h"]);
+    assert.equal(r.status, 0);
+  });
+
+  it("no command exits 0 (printing the banner is the documented zero-arg behaviour)", () => {
+    const r = runCli([]);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /Usage:/i);
+  });
+
+  it("unknown command exits 1 with a stderr message (NOT 0, NOT 2)", () => {
+    // Breaking this = MAJOR. CI shell scripts use `did <subcommand>` and
+    // distinguish "guard violated" (exit 1) from "the binary itself
+    // is broken" (other codes). Returning 0 on a typo would silently
+    // green-light pipelines; returning 2 would diverge from the rest of
+    // the CLI surface.
+    const r = runCli(["this-is-not-a-real-command"]);
+    assert.equal(r.status, 1);
+    assert.ok(r.stderr.length > 0, "unknown command must write to stderr");
+  });
+});
+
+// ─── Section 2: `verify` exit codes (the most-used surface) ──────────
+
+describe("CONTRACT — `verify` exit codes (CLI, issue #35)", () => {
+  it("`verify` with no staged files and no --files exits 0 (no-op success)", () => {
+    // Breaking this = MAJOR. Every Git hook calls `verify`; an empty
+    // commit (e.g. `--allow-empty`, or a hook firing on a clean tree)
+    // MUST NOT block the user.
+    const root = freshGitRepo("verify-empty");
+    const r = runCli(["verify"], root);
+    assert.equal(r.status, 0, `stdout=${r.stdout}\nstderr=${r.stderr}`);
+  });
+
+  it("`verify --files <substantive doc>` exits 0 (clean prose passes)", () => {
+    // Breaking this = MAJOR. The "your normal docs aren't blocked"
+    // contract is the headline DX promise. (PR #60 issue #59 hardened
+    // this against regex-escape false positives — this contract test
+    // is the long-lived guardrail.)
+    const root = freshGitRepo("verify-clean");
+    const docPath = path.join(root, "docs", "ok.md");
+    fs.mkdirSync(path.dirname(docPath), { recursive: true });
+    fs.writeFileSync(
+      docPath,
+      "This document contains a real paragraph of meaningful content well above the default minimum length threshold so length-based findings do not interfere with normal prose.\n",
+    );
+    const r = runCli(["verify", "--files", "docs/ok.md"], root);
+    assert.equal(r.status, 0, `stdout=${r.stdout}\nstderr=${r.stderr}`);
+  });
+
+  it("`verify --files <hollow doc>` exits 1 (BLOCK is non-zero)", () => {
+    // Breaking this = MAJOR. Pre-commit hooks read $? — non-zero is the
+    // ONLY signal Git understands as "abort the commit". Returning 0
+    // here would let hollow content reach the index.
+    const root = freshGitRepo("verify-hollow");
+    const docPath = path.join(root, "docs", "bad.md");
+    fs.mkdirSync(path.dirname(docPath), { recursive: true });
+    fs.writeFileSync(
+      docPath,
+      "This document contains a real paragraph of meaningful content well above the default minimum length threshold but ends with a literal placeholder: PLACEHOLDER right here.\n",
+    );
+    const r = runCli(["verify", "--files", "docs/bad.md"], root);
+    assert.equal(r.status, 1, `stdout=${r.stdout}\nstderr=${r.stderr}`);
+  });
+
+  it("`verify --files <missing path>` exits 0 (guards skip silently — documented)", () => {
+    // Breaking this = MAJOR. Hooks pass file lists from `git diff
+    // --name-only` which can include paths that have already been
+    // deleted (rename / unstage races). Crashing on missing files would
+    // make the hook flaky.
+    const root = freshGitRepo("verify-missing");
+    const r = runCli(["verify", "--files", "docs/never-existed.md"], root);
+    assert.equal(r.status, 0, `stdout=${r.stdout}\nstderr=${r.stderr}`);
+  });
+});
+
+// ─── Section 3: `doctor` & `init` exit codes ─────────────────────────
+
+describe("CONTRACT — `doctor` & `init` exit codes (CLI, issue #35)", () => {
+  it("`doctor` in a healthy fresh repo exits 0", () => {
+    // Breaking this = MAJOR. Onboarding scripts (`did init && did
+    // doctor`) and CI smoke-tests pin this. A non-zero exit on a fresh
+    // clean tree would mean every greenfield project starts red.
+    const root = freshGitRepo("doctor-healthy");
+    const r = runCli(["doctor"], root);
+    assert.equal(r.status, 0, `stdout=${r.stdout}\nstderr=${r.stderr}`);
+  });
+
+  it("`init` in a fresh git repo exits 0 and creates pre-commit + pre-push + defense.config.yml", () => {
+    // Breaking this = MAJOR. README quickstart (`npx defense-in-depth
+    // init`) treats exit 0 + the three artifacts below as success. A
+    // user whose CI-bound install no longer sees these files would
+    // silently lose enforcement.
+    const root = freshGitRepo("init-fresh");
+    const r = runCli(["init"], root);
+    assert.equal(r.status, 0, `stdout=${r.stdout}\nstderr=${r.stderr}`);
+
+    // Pin the on-disk side effects — these are the published
+    // outcomes of `init`, not internals.
+    assert.ok(
+      fs.existsSync(path.join(root, ".git", "hooks", "pre-commit")),
+      "init must install .git/hooks/pre-commit",
+    );
+    assert.ok(
+      fs.existsSync(path.join(root, ".git", "hooks", "pre-push")),
+      "init must install .git/hooks/pre-push",
+    );
+    assert.ok(
+      fs.existsSync(path.join(root, "defense.config.yml")),
+      "init must scaffold defense.config.yml at the project root",
+    );
+  });
+});

--- a/tests/contract/public-api-contract.test.js
+++ b/tests/contract/public-api-contract.test.js
@@ -1,0 +1,372 @@
+/**
+ * Public API CONTRACT tests (issue #35).
+ *
+ * ────────────────────────────────────────────────────────────────────
+ * Breaking any test in this file = SEMVER MAJOR bump per
+ * docs/SEMVER.md §3. These tests are the living specification of the
+ * v1.0 public surface as seen by external consumers. They import ONLY
+ * via the published barrel (`../dist/index.js` — what npm ships); they
+ * do NOT touch internal modules. If the structure of an exported value
+ * or the shape of a returned object changes, a consumer's code breaks
+ * silently — these tests fire first.
+ * ────────────────────────────────────────────────────────────────────
+ *
+ * Scope (deliberately narrower than `tests/public-api.test.js`):
+ *
+ *   public-api.test.js     → "is the symbol exported?" (presence)
+ *   public-api-contract.js → "does the symbol BEHAVE per its contract?"
+ *                            (shape of return values, chainability,
+ *                            constructor signatures, enum stability)
+ *
+ * The two files are complementary. Presence tests catch dropped
+ * re-exports; contract tests catch silent behavioural drift.
+ *
+ * Rule: every assertion below pins a contract that a consumer in the
+ * wild can build against. No assertion should reach into private state
+ * or internal module paths — if a refactor needs to reshape internals,
+ * these tests should keep passing.
+ *
+ * Executor: Devin
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as os from "node:os";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import {
+  DefendEngine,
+  loadConfig,
+  DEFAULT_CONFIG,
+  Severity,
+  EvidenceLevel,
+  hollowArtifactGuard,
+  ssotPollutionGuard,
+  rootPollutionGuard,
+  commitFormatGuard,
+  branchNamingGuard,
+  phaseGateGuard,
+  ticketIdentityGuard,
+  hitlReviewGuard,
+  federationGuard,
+  allBuiltinGuards,
+  createProvider,
+  FileTicketProvider,
+  HttpTicketProvider,
+} from "../../dist/index.js";
+
+// ─── Shared fixture: a throw-away project root ───────────────────────
+function mkProjectRoot() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "did-contract-"));
+  return root;
+}
+
+// ─── Section 1: DefendEngine constructor & instance contracts ────────
+
+describe("CONTRACT — DefendEngine class shape", () => {
+  it("is constructable with projectRoot only (config defaults from disk)", () => {
+    // Breaking this = MAJOR. Many consumers rely on `new DefendEngine(root)`
+    // as their one-liner integration.
+    const root = mkProjectRoot();
+    const engine = new DefendEngine(root);
+    assert.ok(engine instanceof DefendEngine, "constructor must return a DefendEngine instance");
+  });
+
+  it("is constructable with explicit config (DI for tests / overrides)", () => {
+    const root = mkProjectRoot();
+    const engine = new DefendEngine(root, DEFAULT_CONFIG);
+    assert.ok(engine instanceof DefendEngine);
+  });
+
+  it("exposes .use() that returns the engine itself (chainable)", () => {
+    // Breaking this = MAJOR. The README and migration guide both show
+    // `new DefendEngine(root).use(g1).use(g2).run(...)` style.
+    const engine = new DefendEngine(mkProjectRoot(), DEFAULT_CONFIG);
+    const out = engine.use(hollowArtifactGuard);
+    assert.strictEqual(out, engine, ".use() must return `this` for chaining");
+  });
+
+  it("exposes .useAll() that returns the engine itself (chainable)", () => {
+    const engine = new DefendEngine(mkProjectRoot(), DEFAULT_CONFIG);
+    const out = engine.useAll([hollowArtifactGuard, commitFormatGuard]);
+    assert.strictEqual(out, engine, ".useAll() must return `this` for chaining");
+  });
+
+  it("exposes .run() that returns a Promise", () => {
+    const engine = new DefendEngine(mkProjectRoot(), DEFAULT_CONFIG);
+    const p = engine.run([], {});
+    assert.ok(p && typeof p.then === "function", ".run() must return a thenable");
+    return p; // make sure the test waits on it (no unhandled rejection)
+  });
+});
+
+// ─── Section 2: EngineVerdict shape contract ─────────────────────────
+
+describe("CONTRACT — EngineVerdict object shape from engine.run()", () => {
+  it("returns the documented shape: passed | totalGuards | passedGuards | failedGuards | warnedGuards | results | durationMs", async () => {
+    // Breaking this = MAJOR. The fields below are the only guarantees
+    // consumers (CI scripts, hooks, dashboards) can rely on.
+    const engine = new DefendEngine(mkProjectRoot(), DEFAULT_CONFIG)
+      .use(commitFormatGuard);
+    const verdict = await engine.run([], { commitMessage: "feat: contract test" });
+
+    assert.strictEqual(typeof verdict, "object");
+    assert.ok(verdict !== null, "verdict must not be null");
+
+    // Required boolean
+    assert.strictEqual(typeof verdict.passed, "boolean", "passed: boolean");
+
+    // Required counters
+    assert.strictEqual(typeof verdict.totalGuards, "number", "totalGuards: number");
+    assert.strictEqual(typeof verdict.passedGuards, "number", "passedGuards: number");
+    assert.strictEqual(typeof verdict.failedGuards, "number", "failedGuards: number");
+    assert.strictEqual(typeof verdict.warnedGuards, "number", "warnedGuards: number");
+
+    // Required results array
+    assert.ok(Array.isArray(verdict.results), "results: GuardResult[]");
+
+    // Required timing
+    assert.strictEqual(typeof verdict.durationMs, "number", "durationMs: number");
+    assert.ok(verdict.durationMs >= 0, "durationMs must be non-negative");
+
+    // Internal accounting consistency (a published invariant — not
+    // implementation detail). If this fails, the verdict is incoherent
+    // and dashboards reading these fields will mis-render.
+    assert.strictEqual(
+      verdict.totalGuards,
+      verdict.results.length,
+      "totalGuards must equal results.length",
+    );
+    assert.strictEqual(
+      verdict.totalGuards,
+      verdict.passedGuards + verdict.failedGuards,
+      "totalGuards must equal passedGuards + failedGuards",
+    );
+    assert.strictEqual(
+      verdict.passed,
+      verdict.failedGuards === 0,
+      "verdict.passed must be true iff failedGuards === 0",
+    );
+  });
+});
+
+// ─── Section 3: GuardResult shape contract ───────────────────────────
+
+describe("CONTRACT — GuardResult object shape (per-guard output)", () => {
+  it("each result item has guardId | passed | findings | durationMs", async () => {
+    // Breaking this = MAJOR. Every consumer that introspects per-guard
+    // output (custom reporters, IDE plugins) reads exactly these fields.
+    const engine = new DefendEngine(mkProjectRoot(), DEFAULT_CONFIG)
+      .use(hollowArtifactGuard)
+      .use(commitFormatGuard);
+    const verdict = await engine.run([], { commitMessage: "feat: ok" });
+
+    assert.strictEqual(verdict.results.length, 2);
+    for (const r of verdict.results) {
+      assert.strictEqual(typeof r.guardId, "string", "guardId: string");
+      assert.ok(r.guardId.length > 0, "guardId must be non-empty");
+      assert.strictEqual(typeof r.passed, "boolean", "passed: boolean");
+      assert.ok(Array.isArray(r.findings), "findings: Finding[]");
+      assert.strictEqual(typeof r.durationMs, "number", "durationMs: number");
+      assert.ok(r.durationMs >= 0, "durationMs must be non-negative");
+    }
+  });
+
+  it("Finding objects (when present) have guardId | severity | message", async () => {
+    // Force at least one Finding by feeding an obviously bad commit message.
+    const engine = new DefendEngine(mkProjectRoot(), DEFAULT_CONFIG).use(commitFormatGuard);
+    const verdict = await engine.run([], { commitMessage: "no type prefix here" });
+    const findings = verdict.results.flatMap((r) => r.findings);
+    assert.ok(findings.length >= 1, "expected at least one finding for bad commit message");
+
+    for (const f of findings) {
+      assert.strictEqual(typeof f.guardId, "string", "Finding.guardId: string");
+      assert.strictEqual(typeof f.severity, "string", "Finding.severity: string");
+      assert.ok(
+        Object.values(Severity).includes(f.severity),
+        `Finding.severity must be one of Severity values, got ${f.severity}`,
+      );
+      assert.strictEqual(typeof f.message, "string", "Finding.message: string");
+      assert.ok(f.message.length > 0, "Finding.message must be non-empty");
+    }
+  });
+});
+
+// ─── Section 4: Guard interface shape contract ───────────────────────
+
+describe("CONTRACT — Guard interface shape (every built-in)", () => {
+  for (const guard of allBuiltinGuards) {
+    it(`${guard.id}: id | name | description | check() per Guard contract`, () => {
+      // Breaking this = MAJOR. User-authored guards rely on this exact
+      // shape (it is THE pluggability contract) — see
+      // .agents/contracts/guard-interface.md.
+      assert.strictEqual(typeof guard.id, "string");
+      assert.ok(guard.id.length > 0, "Guard.id must be non-empty");
+
+      assert.strictEqual(typeof guard.name, "string", `Guard.name on ${guard.id}`);
+      assert.ok(guard.name.length > 0, `Guard.name must be non-empty on ${guard.id}`);
+
+      assert.strictEqual(
+        typeof guard.description,
+        "string",
+        `Guard.description on ${guard.id}`,
+      );
+      assert.ok(
+        guard.description.length > 0,
+        `Guard.description must be non-empty on ${guard.id}`,
+      );
+
+      assert.strictEqual(typeof guard.check, "function", `Guard.check on ${guard.id}`);
+      // Guard.check must take a single ctx argument per the contract.
+      assert.strictEqual(guard.check.length, 1, `Guard.check must accept exactly 1 argument on ${guard.id}`);
+    });
+  }
+
+  it("every built-in guard has a unique id (no collisions in registry)", () => {
+    const ids = allBuiltinGuards.map((g) => g.id);
+    const unique = new Set(ids);
+    assert.strictEqual(
+      ids.length,
+      unique.size,
+      `duplicate guard ids in allBuiltinGuards: ${ids.join(", ")}`,
+    );
+  });
+});
+
+// ─── Section 5: Severity & EvidenceLevel enum contracts ──────────────
+
+describe("CONTRACT — enum value stability", () => {
+  it("Severity has EXACTLY {PASS:'pass', WARN:'warn', BLOCK:'block'} — no more, no less", () => {
+    // Breaking this = MAJOR. Severity values are persisted in
+    // dashboards, lesson logs, and CI output. Adding a new severity is
+    // additive (Minor); REMOVING or RENAMING one is breaking.
+    assert.deepStrictEqual(
+      { ...Severity },
+      { PASS: "pass", WARN: "warn", BLOCK: "block" },
+      "Severity enum value-set must match the v1.0 contract",
+    );
+  });
+
+  it("EvidenceLevel has EXACTLY {CODE, RUNTIME, INFER, HYPO} with stable string values", () => {
+    assert.deepStrictEqual(
+      { ...EvidenceLevel },
+      {
+        CODE: "CODE",
+        RUNTIME: "RUNTIME",
+        INFER: "INFER",
+        HYPO: "HYPO",
+      },
+      "EvidenceLevel enum value-set must match the v1.0 contract",
+    );
+  });
+});
+
+// ─── Section 6: Config contracts ─────────────────────────────────────
+
+describe("CONTRACT — loadConfig & DEFAULT_CONFIG shape", () => {
+  it("loadConfig(<no defense.config.yml>) returns the documented defaults", () => {
+    // Breaking this = MAJOR. The "zero-config out of the box" promise
+    // is the headline value prop in README §1 — `loadConfig()` on a
+    // fresh repo MUST return a usable DefendConfig with all guards
+    // present.
+    const root = mkProjectRoot(); // no defense.config.yml inside
+    const cfg = loadConfig(root);
+    assert.strictEqual(typeof cfg, "object");
+    assert.ok(cfg.guards && typeof cfg.guards === "object", "cfg.guards must be an object");
+
+    // Defaults ship configuration for the seven always-on guards.
+    // `hitlReview` and `federation` are deliberately opt-in (they
+    // require user-supplied policy / a ticket provider) and are NOT in
+    // DEFAULT_CONFIG.guards by design — verified by the explicit
+    // negative assertions below.
+    for (const expectedKey of [
+      "hollowArtifact",
+      "ssotPollution",
+      "rootPollution",
+      "commitFormat",
+      "branchNaming",
+      "phaseGate",
+      "ticketIdentity",
+    ]) {
+      assert.ok(
+        expectedKey in cfg.guards,
+        `cfg.guards.${expectedKey} must be present in defaults`,
+      );
+    }
+    for (const optInKey of ["hitlReview", "federation"]) {
+      assert.ok(
+        !(optInKey in cfg.guards),
+        `cfg.guards.${optInKey} is opt-in and MUST NOT appear in defaults`,
+      );
+    }
+  });
+
+  it("DEFAULT_CONFIG is a real, non-empty DefendConfig instance", () => {
+    assert.strictEqual(typeof DEFAULT_CONFIG, "object");
+    assert.ok(DEFAULT_CONFIG !== null);
+    assert.ok(
+      typeof DEFAULT_CONFIG.guards === "object" && DEFAULT_CONFIG.guards !== null,
+      "DEFAULT_CONFIG.guards must be a non-null object",
+    );
+  });
+});
+
+// ─── Section 7: Federation provider contracts ────────────────────────
+
+describe("CONTRACT — federation provider factory & TicketStateProvider shape", () => {
+  it("createProvider(undefined) returns a FileTicketProvider instance (default)", () => {
+    const p = createProvider(undefined, undefined, mkProjectRoot());
+    assert.ok(
+      p instanceof FileTicketProvider,
+      "default provider must be FileTicketProvider",
+    );
+  });
+
+  it("createProvider('file') returns a FileTicketProvider instance", () => {
+    const p = createProvider("file", undefined, mkProjectRoot());
+    assert.ok(p instanceof FileTicketProvider);
+  });
+
+  it("createProvider('http') returns an HttpTicketProvider instance", () => {
+    const p = createProvider("http", { endpoint: "http://localhost:0" }, mkProjectRoot());
+    assert.ok(p instanceof HttpTicketProvider);
+  });
+
+  it("createProvider(<unknown>) gracefully degrades to the file provider (does NOT throw)", () => {
+    // Breaking this = MAJOR. The graceful-degradation contract is
+    // documented in src/federation/index.ts and is what allows users
+    // to upgrade a config without taking down the pipeline.
+    const root = mkProjectRoot();
+    const p = createProvider("does-not-exist-12345", undefined, root);
+    assert.ok(
+      p instanceof FileTicketProvider,
+      "unknown provider must fall back to FileTicketProvider, not throw",
+    );
+  });
+
+  it("every TicketStateProvider exposes the documented interface (name | resolve | optional dispose)", async () => {
+    const cases = [
+      createProvider("file", undefined, mkProjectRoot()),
+      createProvider("http", { endpoint: "http://localhost:0" }, mkProjectRoot()),
+    ];
+
+    for (const p of cases) {
+      assert.strictEqual(typeof p.name, "string", "provider.name: string");
+      assert.ok(p.name.length > 0, "provider.name must be non-empty");
+
+      assert.strictEqual(typeof p.resolve, "function", "provider.resolve: function");
+      // resolve(ticketId) — exactly 1 documented param.
+      assert.strictEqual(
+        p.resolve.length,
+        1,
+        "provider.resolve must accept exactly 1 argument (ticketId)",
+      );
+
+      // dispose is optional. If present, must be a function.
+      if ("dispose" in p && p.dispose !== undefined) {
+        assert.strictEqual(typeof p.dispose, "function", "provider.dispose: function (when present)");
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Description

Closes #35 — adds `tests/contract/` with two consumer-perspective contract test files (39 tests in total). Each assertion pins a v1.0 surface promise — **breaking any test in `tests/contract/` is a SEMVER MAJOR bump per [`docs/SEMVER.md` §3](https://github.com/tamld/defense-in-depth/blob/main/docs/SEMVER.md). The header comment in both files makes this explicit.

Both files import **only** through the published barrel paths (`../../dist/index.js` for the JS API, spawning the compiled `dist/cli/index.js` for the CLI). They never reach into internal `src/*` modules — exactly as a downstream consumer would.

Fixes #35

### Why two files (and not duplicating existing tests)

| File | Question it answers | Status |
|:---|:---|:---|
| `tests/public-api.test.js` (PR #56) | *Is the symbol exported?* (presence) | unchanged |
| `tests/contract/public-api-contract.test.js` | *Does the symbol BEHAVE per its contract?* (shape of return values, chainability, constructor signatures, enum stability) | **new** |
| `tests/cli-ground-truth.test.js` | Broad behavioural matrix of `verify` under many config / file shapes | unchanged |
| `tests/contract/cli-exit-codes.test.js` | The **thin** exit-code promise that Git hooks, CI shell scripts, and Lefthook configs branch on | **new** |

The two new files are intentionally complementary. Presence tests catch dropped re-exports; contract tests catch silent behavioural drift.

### Coverage matrix

`tests/contract/public-api-contract.test.js` — **27 tests across 7 sections**:

1. **`DefendEngine` class shape** — constructable with `projectRoot` only, with explicit `DefendConfig`, `.use()` / `.useAll()` chainable, `.run()` returns a Promise.
2. **`EngineVerdict` shape from `engine.run()`** — `passed | totalGuards | passedGuards | failedGuards | warnedGuards | results | durationMs` plus the internal accounting invariants (`totalGuards === results.length`, `passed ⇔ failedGuards === 0`).
3. **`GuardResult` shape** — `guardId | passed | findings | durationMs`; `Finding` shape: `guardId | severity | message`.
4. **`Guard` interface shape on every built-in** — `id | name | description | check(ctx)` per [`.agents/contracts/guard-interface.md`](.agents/contracts/guard-interface.md), plus the unique-id invariant across `allBuiltinGuards`.
5. **`Severity` & `EvidenceLevel` enum value-set stability** — exhaustive deep-equal against the v1.0 contract (adding a value is Minor; removing/renaming is Major).
6. **`loadConfig` & `DEFAULT_CONFIG`** — zero-config default behaviour: 7 always-on guards present; `hitlReview` and `federation` are explicitly opt-in and asserted ABSENT from defaults.
7. **Federation provider factory** — `createProvider(undefined | 'file' | 'http' | <unknown>)`, graceful degradation on unknown provider (does NOT throw, falls back to `FileTicketProvider`), `TicketStateProvider` shape: `name | resolve(ticketId) | optional dispose`.

`tests/contract/cli-exit-codes.test.js` — **12 tests across 3 sections**:

1. **Meta commands** — `--version` / `-v` / `--help` / `-h` / no-args (all exit 0) / unknown command (exit 1, stderr non-empty). The `--version` test also pins a semver-shape regex on stdout so the contract covers more than just the exit code.
2. **`verify` subcommand** — empty-repo no-op → 0; clean substantive doc → 0; hollow doc with literal placeholder → 1 (BLOCK); missing path → 0 (documented silent-skip for hook robustness, complements PR #60).
3. **`doctor` & `init` subcommands** — `doctor` on a healthy fresh repo → 0; `init` creates `pre-commit` + `pre-push` + `defense.config.yml` and exits 0 (README quickstart contract).

### Acceptance criteria (from #35)

- [x] `tests/contract/` directory with at least 2 test files (2 added, 39 tests total).
- [x] Tests import ONLY from the public surface (compiled barrel + spawned CLI), never from internal modules.
- [x] Tests verify **shape**, not implementation details — every assertion pins published surface (return-value keys, exit codes, on-disk side effects), no internals.
- [x] All tests pass in CI — locally green; CI run on this PR.
- [x] Comment in test file: `Breaking any of these tests = SEMVER MAJOR bump` — present in the header of both files.

### Implementation notes

- `tsconfig.json` already excludes `tests/**`, so the new directory does not perturb the build.
- `scripts/check-coverage.mjs` globs `tests/**/*.test.js`, so the new files are picked up by the coverage gate without any config change.
- `tests/contract/cli-exit-codes.test.js` uses fresh `git init` fixtures inside `os.tmpdir()` and forces `CI=true` + `NO_COLOR=1` in the spawned env — mirrors the existing `tests/cli-ground-truth.test.js` discipline.

Fixes #35

## Type of Change

- [ ] 🐛 Bug fix (non-breaking)
- [ ] ✨ New feature (non-breaking)
- [ ] 🛡️ New guard
- [ ] 💥 Breaking change
- [ ] 📝 Documentation only
- [ ] 🔧 Refactor (no behavior change)
- [x] 🧪 Tests only (test-only addition; no source change — pins the existing v1.0 surface)

## Checklist

- [x] My code follows the [consistency rules](.agents/rules/rule-consistency.md)
- [x] I used conventional commit format for the PR title
- [x] I added tests for new functionality — this PR IS the test addition
- [x] All existing tests pass (`npm test`) — 431/431 (was 392 + 39 new)
- [x] I updated documentation (README, CHANGELOG) if needed — N/A; the contract is self-documenting via header comments + per-test JSDoc inside the new files
- [x] New guards implement the `Guard` interface from `core/types.ts` — N/A (no guard added)
- [x] No `any` types used
- [x] No new external dependencies added

## For New Guards Only

N/A — test-only PR, no guard added.

## Evidence

`[RUNTIME]` Targeted runs of the two new files:

```
$ node --test tests/contract/public-api-contract.test.js
…
ℹ tests 27
ℹ pass 27
ℹ fail 0

$ node --test tests/contract/cli-exit-codes.test.js
…
ℹ tests 12
ℹ pass 12
ℹ fail 0
```

`[RUNTIME]` Full suite + lint:

```
$ npm run lint
> tsc --noEmit
(clean)

$ npm test
…
ℹ tests 431
ℹ pass 431
ℹ fail 0
```

`[CODE]` SemVer class: **Patch** per [`docs/SEMVER.md` §4](https://github.com/tamld/defense-in-depth/blob/main/docs/SEMVER.md) — test-only change, no public surface movement, no behaviour change. The whole point of this PR is to pin the surface, not to move it.

Refs #42 (umbrella v1.0.0 release lifecycle).

Executor: Devin

Link to Devin session: https://app.devin.ai/sessions/8db2c99daa344211a783529bd088be68
Requested by: @tamld
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tamld/defense-in-depth/pull/63" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
