### PR TITLE
refactor(core): extract shared jsonl-store with runtime validation (closes #43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI dogfooding** (`ci.yml`) — removed the `|| true` swallow on `Self-verify`. Step is now an honest CLI smoke test; meaningful diff-based dogfooding is a follow-up that requires a repo-local `defense.config.yml` tuned for self-application.
 - **SECURITY.md supported versions** — corrected from `0.1.x` to `0.6.x` to match the current minor line.
 
+### Refactor
+- **Shared `src/core/jsonl-store.ts`** (#43, T1) — extracted the duplicated append-only JSONL primitives (id-based dedupe, time-window dedupe, line-by-line reader, malformed-line tolerance) from `feedback.ts` and `lesson-outcome.ts` into a single typed factory. Adds runtime field-by-field validation that replaces the previous `JSON.parse(line) as T` casts (Antigravity finding #4 on PR #32). External signatures of `appendFeedback`, `appendRecall`, `appendOutcome`, `readFeedback`, `readRecalls`, `readOutcomes` are unchanged — purely an implementation detail that is pinned by the contract tests added in #35. Patch-class per `docs/SEMVER.md` §4.
+
 ### Migration
 
 No code or config changes are required for users on v0.6.0. The Composite

--- a/src/core/feedback.ts
+++ b/src/core/feedback.ts
@@ -26,6 +26,15 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 import { computeF1 } from "./f1.js";
+import {
+  createJsonlStore,
+  getOptionalString,
+  getString,
+  isObjectWithId,
+  isStringEnum,
+  type JsonlSchema,
+  type JsonlStore,
+} from "./jsonl-store.js";
 import type { FeedbackEvent, GuardF1Metric } from "./types.js";
 
 const FEEDBACK_JSONL = ".agents/records/feedback.jsonl";
@@ -33,6 +42,50 @@ const SCRAPER_CURSOR = ".agents/state/feedback-scraper-cursor.json";
 const SCRAPER_VERSION = "scraper:v1";
 const FIXUP_WINDOW_MS = 4 * 60 * 60 * 1000;
 const REVERT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+// JSONL schema for `.agents/records/feedback.jsonl` (issue #43).
+const FEEDBACK_LABELS = ["TP", "FP", "FN", "TN"] as const;
+const FEEDBACK_SOURCES = [
+  "cli",
+  "scraper-fixup",
+  "scraper-revert",
+  "scraper-override",
+  "scraper-clean",
+] as const;
+
+const feedbackSchema: JsonlSchema<FeedbackEvent> = {
+  validate(raw: unknown): FeedbackEvent | null {
+    if (!isObjectWithId(raw)) return null;
+    const guardId = getString(raw, "guardId");
+    const ticketId = getString(raw, "ticketId");
+    const findingHash = getString(raw, "findingHash");
+    const label = isStringEnum(raw, "label", FEEDBACK_LABELS);
+    const source = isStringEnum(raw, "source", FEEDBACK_SOURCES);
+    const timestamp = getString(raw, "timestamp");
+    const executor = getString(raw, "executor");
+    const note = getOptionalString(raw, "note");
+    if (
+      guardId === null || ticketId === null || findingHash === null ||
+      label === null || source === null || timestamp === null ||
+      executor === null || note === null
+    ) return null;
+    const event: FeedbackEvent = {
+      id: raw.id as string,
+      guardId, ticketId, findingHash, label, source, timestamp, executor,
+    };
+    if (note !== undefined) event.note = note;
+    return event;
+  },
+  idOf: (e) => e.id,
+  timestampOf: (e) => e.timestamp,
+};
+
+function getFeedbackStore(projectRoot: string): JsonlStore<FeedbackEvent> {
+  return createJsonlStore<FeedbackEvent>(
+    path.resolve(projectRoot, FEEDBACK_JSONL),
+    feedbackSchema,
+  );
+}
 
 // ──────────────────────────────────────────────────────────────────────────
 // Hashing & ID
@@ -89,33 +142,17 @@ export interface AppendFeedbackResult {
  * Idempotent: if the event id already exists in the file, this is a no-op
  * and `written` is false. Callers (CLI, scraper) decide how to surface that
  * to the user — typically a stderr WARN.
+ *
+ * Implementation delegated to the shared {@link createJsonlStore} factory
+ * (issue #43) so the on-disk semantics + runtime validation match
+ * `lesson-outcome.ts` byte-for-byte.
  */
 export function appendFeedback(
   projectRoot: string,
   event: FeedbackEvent,
 ): AppendFeedbackResult {
-  const filePath = path.resolve(projectRoot, FEEDBACK_JSONL);
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-
-  if (fs.existsSync(filePath)) {
-    const existing = fs.readFileSync(filePath, "utf-8");
-    for (const line of existing.split("\n")) {
-      if (!line.trim()) continue;
-      try {
-        const parsed = JSON.parse(line) as FeedbackEvent;
-        if (parsed.id === event.id) {
-          return { written: false, event: parsed, path: filePath };
-        }
-      } catch {
-        // Tolerate malformed lines; do not crash the writer over a corrupt
-        // historical entry.
-        continue;
-      }
-    }
-  }
-
-  fs.appendFileSync(filePath, JSON.stringify(event) + "\n", "utf-8");
-  return { written: true, event, path: filePath };
+  const result = getFeedbackStore(projectRoot).append(event);
+  return { written: result.written, event: result.event, path: result.path };
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -135,17 +172,15 @@ export interface ReadFeedbackOptions {
  * Read all matching {@link FeedbackEvent}s from disk. Returns `[]` when the
  * file does not exist (graceful — Persona A who never ran feedback gets an
  * empty list, not a crash).
+ *
+ * Implementation delegated to {@link createJsonlStore} (issue #43) — the
+ * `period` filter is feedback-specific so it lives here as a custom
+ * predicate; everything else (since/limit/runtime validation) is shared.
  */
 export function readFeedback(
   projectRoot: string,
   options: ReadFeedbackOptions = {},
 ): FeedbackEvent[] {
-  const filePath = path.resolve(projectRoot, FEEDBACK_JSONL);
-  if (!fs.existsSync(filePath)) return [];
-
-  const lines = fs.readFileSync(filePath, "utf-8").split("\n");
-  const events: FeedbackEvent[] = [];
-
   let periodStart: number | undefined;
   let periodEnd: number | undefined;
   if (options.period) {
@@ -155,32 +190,21 @@ export function readFeedback(
       periodEnd = Date.parse(parts[1]);
     }
   }
-  const sinceMs = options.since ? Date.parse(options.since) : undefined;
 
-  for (const line of lines) {
-    if (!line.trim()) continue;
-    let event: FeedbackEvent;
-    try {
-      event = JSON.parse(line) as FeedbackEvent;
-    } catch {
-      continue;
-    }
-
-    if (options.guardId && event.guardId !== options.guardId) continue;
-
-    if (periodStart !== undefined && periodEnd !== undefined) {
-      const ts = Date.parse(event.timestamp);
-      if (Number.isNaN(ts) || ts < periodStart || ts >= periodEnd) continue;
-    }
-    if (sinceMs !== undefined && !Number.isNaN(sinceMs)) {
-      const ts = Date.parse(event.timestamp);
-      if (Number.isNaN(ts) || ts < sinceMs) continue;
-    }
-
-    events.push(event);
-    if (options.limit !== undefined && events.length >= options.limit) break;
-  }
-  return events;
+  return getFeedbackStore(projectRoot).read({
+    since: options.since,
+    limit: options.limit,
+    filter: (event) => {
+      if (options.guardId && event.guardId !== options.guardId) return false;
+      if (periodStart !== undefined && periodEnd !== undefined) {
+        const ts = Date.parse(event.timestamp);
+        if (Number.isNaN(ts) || ts < periodStart || ts >= periodEnd) {
+          return false;
+        }
+      }
+      return true;
+    },
+  });
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/core/jsonl-store.ts
+++ b/src/core/jsonl-store.ts
@@ -1,0 +1,191 @@
+/**
+ * Shared append-only JSONL store with runtime validation (issue #43).
+ * Extracted from the duplicated I/O in `feedback.ts` and `lesson-outcome.ts`
+ * — same id-dedupe + same line-by-line reader + same `JSON.parse(line) as T`
+ * cast. The cast is the type-without-validation surface Antigravity flagged
+ * on PR #32. The `validate` hook narrows untrusted JSON field by field.
+ *
+ * Executor: Devin
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export interface JsonlSchema<T> {
+  validate: (raw: unknown) => T | null;
+  idOf: (record: T) => string;
+  timestampOf?: (record: T) => string | undefined;
+}
+
+export interface JsonlAppendResult<T> {
+  written: boolean;
+  event: T;
+  path: string;
+  windowDeduped?: boolean;
+}
+
+export interface JsonlAppendWindowOptions<T> {
+  windowMs: number;
+  windowKeyOf: (record: T) => string;
+}
+
+export interface JsonlReadOptions<T> {
+  filter?: (record: T) => boolean;
+  since?: string;
+  limit?: number;
+}
+
+export interface JsonlStore<T> {
+  readonly path: string;
+  append(record: T): JsonlAppendResult<T>;
+  appendWithWindow(
+    record: T,
+    options: JsonlAppendWindowOptions<T>,
+  ): JsonlAppendResult<T>;
+  read(options?: JsonlReadOptions<T>): T[];
+  exists(id: string): boolean;
+}
+
+export function createJsonlStore<T>(
+  filePath: string,
+  schema: JsonlSchema<T>,
+): JsonlStore<T> {
+  function readAll(): T[] {
+    if (!fs.existsSync(filePath)) return [];
+    const out: T[] = [];
+    for (const line of fs.readFileSync(filePath, "utf-8").split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      const v = schema.validate(parsed);
+      if (v !== null) out.push(v);
+    }
+    return out;
+  }
+
+  function append(record: T): JsonlAppendResult<T> {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const targetId = schema.idOf(record);
+    for (const existing of readAll()) {
+      if (schema.idOf(existing) === targetId) {
+        return { written: false, event: existing, path: filePath };
+      }
+    }
+    fs.appendFileSync(filePath, JSON.stringify(record) + "\n", "utf-8");
+    return { written: true, event: record, path: filePath };
+  }
+
+  function appendWithWindow(
+    record: T,
+    options: JsonlAppendWindowOptions<T>,
+  ): JsonlAppendResult<T> {
+    if (!schema.timestampOf) {
+      throw new Error(
+        "createJsonlStore: appendWithWindow requires schema.timestampOf",
+      );
+    }
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const targetId = schema.idOf(record);
+    const incomingTsRaw = schema.timestampOf(record);
+    const incomingTs = incomingTsRaw ? Date.parse(incomingTsRaw) : NaN;
+    const incomingKey = options.windowKeyOf(record);
+
+    for (const existing of readAll()) {
+      if (schema.idOf(existing) === targetId) {
+        return { written: false, event: existing, path: filePath };
+      }
+      if (Number.isNaN(incomingTs)) continue;
+      if (options.windowKeyOf(existing) !== incomingKey) continue;
+      const eTsRaw = schema.timestampOf(existing);
+      const eTs = eTsRaw ? Date.parse(eTsRaw) : NaN;
+      if (Number.isNaN(eTs)) continue;
+      if (Math.abs(incomingTs - eTs) <= options.windowMs) {
+        return {
+          written: false,
+          event: existing,
+          path: filePath,
+          windowDeduped: true,
+        };
+      }
+    }
+    fs.appendFileSync(filePath, JSON.stringify(record) + "\n", "utf-8");
+    return { written: true, event: record, path: filePath };
+  }
+
+  function read(options: JsonlReadOptions<T> = {}): T[] {
+    const sinceMs = options.since ? Date.parse(options.since) : undefined;
+    if (sinceMs !== undefined && !schema.timestampOf) {
+      throw new Error(
+        "createJsonlStore: read({since}) requires schema.timestampOf",
+      );
+    }
+    const out: T[] = [];
+    for (const r of readAll()) {
+      if (options.filter && !options.filter(r)) continue;
+      if (sinceMs !== undefined && !Number.isNaN(sinceMs)) {
+        const tsRaw = schema.timestampOf!(r);
+        const ts = tsRaw ? Date.parse(tsRaw) : NaN;
+        if (Number.isNaN(ts) || ts < sinceMs) continue;
+      }
+      out.push(r);
+      if (options.limit !== undefined && out.length >= options.limit) break;
+    }
+    return out;
+  }
+
+  function exists(id: string): boolean {
+    for (const r of readAll()) {
+      if (schema.idOf(r) === id) return true;
+    }
+    return false;
+  }
+
+  return { path: filePath, append, appendWithWindow, read, exists };
+}
+
+// Validator helpers shared by every schema in the project.
+
+/** Narrow `unknown` to a record with a non-empty string `id`. */
+export function isObjectWithId(raw: unknown): raw is Record<string, unknown> {
+  return (
+    typeof raw === "object" && raw !== null && !Array.isArray(raw) &&
+    typeof (raw as { id?: unknown }).id === "string" &&
+    (raw as { id: string }).id.length > 0
+  );
+}
+
+/** `raw[key]` if it's a string, else null. */
+export function getString(
+  raw: Record<string, unknown>,
+  key: string,
+): string | null {
+  const v = raw[key];
+  return typeof v === "string" ? v : null;
+}
+
+/** `undefined` if absent, the string if present, `null` if wrong type. */
+export function getOptionalString(
+  raw: Record<string, unknown>,
+  key: string,
+): string | undefined | null {
+  if (!(key in raw)) return undefined;
+  const v = raw[key];
+  if (v === undefined) return undefined;
+  return typeof v === "string" ? v : null;
+}
+
+/** Narrow `raw[key]` to one of `allowed`. */
+export function isStringEnum<E extends string>(
+  raw: Record<string, unknown>,
+  key: string,
+  allowed: readonly E[],
+): E | null {
+  const v = raw[key];
+  if (typeof v !== "string") return null;
+  return (allowed as readonly string[]).includes(v) ? (v as E) : null;
+}

--- a/src/core/lesson-outcome.ts
+++ b/src/core/lesson-outcome.ts
@@ -36,6 +36,15 @@ import {
   DEFAULT_DSPY_ENDPOINT,
   DEFAULT_DSPY_TIMEOUT_MS,
 } from "./dspy-client.js";
+import {
+  createJsonlStore,
+  getOptionalString,
+  getString,
+  isObjectWithId,
+  isStringEnum,
+  type JsonlSchema,
+  type JsonlStore,
+} from "./jsonl-store.js";
 
 const RECALLS_JSONL = ".agents/records/lesson-recalls.jsonl";
 const OUTCOMES_JSONL = ".agents/records/lesson-outcomes.jsonl";
@@ -44,6 +53,83 @@ const SCANNER_VERSION = "scanner:v1";
 export const RECALL_DEDUPE_WINDOW_MS = 60 * 60 * 1000;
 /** How far back the scanner looks for diffs after a recall (default 30d). */
 const SCAN_LOOKAHEAD_MS = 30 * 24 * 60 * 60 * 1000;
+
+// JSONL schemas for recalls + outcomes (issue #43).
+const RECALL_MATCH_METHODS = ["string", "semantic"] as const;
+const RECALL_SOURCES = ["search", "cli-explicit"] as const;
+const OUTCOME_SOURCES = [
+  "cli-explicit", "scanner-pattern-match", "scanner-no-match",
+] as const;
+
+const recallSchema: JsonlSchema<RecallEvent> = {
+  validate(raw: unknown): RecallEvent | null {
+    if (!isObjectWithId(raw)) return null;
+    const lessonId = getString(raw, "lessonId");
+    const ticketId = getString(raw, "ticketId");
+    const queryHash = getString(raw, "queryHash");
+    const matchMethod = isStringEnum(raw, "matchMethod", RECALL_MATCH_METHODS);
+    const source = isStringEnum(raw, "source", RECALL_SOURCES);
+    const timestamp = getString(raw, "timestamp");
+    const executor = getString(raw, "executor");
+    if (
+      lessonId === null || ticketId === null || queryHash === null ||
+      matchMethod === null || source === null || timestamp === null ||
+      executor === null
+    ) return null;
+    return {
+      id: raw.id as string,
+      lessonId, ticketId, queryHash, matchMethod, source, timestamp, executor,
+    };
+  },
+  idOf: (e) => e.id,
+  timestampOf: (e) => e.timestamp,
+};
+
+const outcomeSchema: JsonlSchema<LessonOutcome> = {
+  validate(raw: unknown): LessonOutcome | null {
+    if (!isObjectWithId(raw)) return null;
+    const recallId = getString(raw, "recallId");
+    const lessonId = getString(raw, "lessonId");
+    const source = isStringEnum(raw, "source", OUTCOME_SOURCES);
+    const timestamp = getString(raw, "timestamp");
+    const executor = getString(raw, "executor");
+    const matchedPattern = getOptionalString(raw, "matchedPattern");
+    const note = getOptionalString(raw, "note");
+    if (
+      recallId === null || lessonId === null || source === null ||
+      timestamp === null || executor === null ||
+      matchedPattern === null || note === null
+    ) return null;
+    // `helpful: boolean | null` — must be one of the three; absent is invalid.
+    const r = raw as Record<string, unknown>;
+    if (!("helpful" in r)) return null;
+    const helpful = r.helpful;
+    if (helpful !== true && helpful !== false && helpful !== null) return null;
+    const event: LessonOutcome = {
+      id: raw.id as string,
+      recallId, lessonId, helpful, source, timestamp, executor,
+    };
+    if (matchedPattern !== undefined) event.matchedPattern = matchedPattern;
+    if (note !== undefined) event.note = note;
+    return event;
+  },
+  idOf: (e) => e.id,
+  timestampOf: (e) => e.timestamp,
+};
+
+function getRecallStore(projectRoot: string): JsonlStore<RecallEvent> {
+  return createJsonlStore<RecallEvent>(
+    path.resolve(projectRoot, RECALLS_JSONL),
+    recallSchema,
+  );
+}
+
+function getOutcomeStore(projectRoot: string): JsonlStore<LessonOutcome> {
+  return createJsonlStore<LessonOutcome>(
+    path.resolve(projectRoot, OUTCOMES_JSONL),
+    outcomeSchema,
+  );
+}
 
 // ──────────────────────────────────────────────────────────────────────────
 // Hashing & ID
@@ -129,50 +215,19 @@ export function appendRecall(
   event: RecallEvent,
   options: AppendRecallOptions = {},
 ): AppendRecallResult {
-  const filePath = path.resolve(projectRoot, RECALLS_JSONL);
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-
   const windowMs = options.dedupeWindowMs ?? RECALL_DEDUPE_WINDOW_MS;
-  const incomingTs = Date.parse(event.timestamp);
-
-  if (fs.existsSync(filePath)) {
-    const existing = fs.readFileSync(filePath, "utf-8");
-    for (const line of existing.split("\n")) {
-      if (!line.trim()) continue;
-      let parsed: RecallEvent;
-      try {
-        parsed = JSON.parse(line) as RecallEvent;
-      } catch {
-        continue;
-      }
-      if (parsed.id === event.id) {
-        return { written: false, event: parsed, path: filePath };
-      }
-      if (
-        !Number.isNaN(incomingTs) &&
-        parsed.lessonId === event.lessonId &&
-        parsed.ticketId === event.ticketId &&
-        parsed.queryHash === event.queryHash &&
-        parsed.matchMethod === event.matchMethod
-      ) {
-        const otherTs = Date.parse(parsed.timestamp);
-        if (
-          !Number.isNaN(otherTs) &&
-          Math.abs(incomingTs - otherTs) <= windowMs
-        ) {
-          return {
-            written: false,
-            event: parsed,
-            path: filePath,
-            windowDeduped: true,
-          };
-        }
-      }
-    }
-  }
-
-  fs.appendFileSync(filePath, JSON.stringify(event) + "\n", "utf-8");
-  return { written: true, event, path: filePath };
+  const result = getRecallStore(projectRoot).appendWithWindow(event, {
+    windowMs,
+    windowKeyOf: (e) =>
+      `${e.lessonId}|${e.ticketId}|${e.queryHash}|${e.matchMethod}`,
+  });
+  const out: AppendRecallResult = {
+    written: result.written,
+    event: result.event,
+    path: result.path,
+  };
+  if (result.windowDeduped) out.windowDeduped = true;
+  return out;
 }
 
 /**
@@ -184,26 +239,8 @@ export function appendOutcome(
   projectRoot: string,
   event: LessonOutcome,
 ): AppendOutcomeResult {
-  const filePath = path.resolve(projectRoot, OUTCOMES_JSONL);
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-
-  if (fs.existsSync(filePath)) {
-    const existing = fs.readFileSync(filePath, "utf-8");
-    for (const line of existing.split("\n")) {
-      if (!line.trim()) continue;
-      try {
-        const parsed = JSON.parse(line) as LessonOutcome;
-        if (parsed.id === event.id) {
-          return { written: false, event: parsed, path: filePath };
-        }
-      } catch {
-        continue;
-      }
-    }
-  }
-
-  fs.appendFileSync(filePath, JSON.stringify(event) + "\n", "utf-8");
-  return { written: true, event, path: filePath };
+  const result = getOutcomeStore(projectRoot).append(event);
+  return { written: result.written, event: result.event, path: result.path };
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -222,29 +259,15 @@ export function readRecalls(
   projectRoot: string,
   options: ReadRecallsOptions = {},
 ): RecallEvent[] {
-  const filePath = path.resolve(projectRoot, RECALLS_JSONL);
-  if (!fs.existsSync(filePath)) return [];
-  const lines = fs.readFileSync(filePath, "utf-8").split("\n");
-  const sinceMs = options.since ? Date.parse(options.since) : undefined;
-  const out: RecallEvent[] = [];
-  for (const line of lines) {
-    if (!line.trim()) continue;
-    let event: RecallEvent;
-    try {
-      event = JSON.parse(line) as RecallEvent;
-    } catch {
-      continue;
-    }
-    if (options.lessonId && event.lessonId !== options.lessonId) continue;
-    if (options.ticketId && event.ticketId !== options.ticketId) continue;
-    if (sinceMs !== undefined && !Number.isNaN(sinceMs)) {
-      const ts = Date.parse(event.timestamp);
-      if (Number.isNaN(ts) || ts < sinceMs) continue;
-    }
-    out.push(event);
-    if (options.limit !== undefined && out.length >= options.limit) break;
-  }
-  return out;
+  return getRecallStore(projectRoot).read({
+    since: options.since,
+    limit: options.limit,
+    filter: (event) => {
+      if (options.lessonId && event.lessonId !== options.lessonId) return false;
+      if (options.ticketId && event.ticketId !== options.ticketId) return false;
+      return true;
+    },
+  });
 }
 
 export interface ReadOutcomesOptions {
@@ -257,24 +280,14 @@ export function readOutcomes(
   projectRoot: string,
   options: ReadOutcomesOptions = {},
 ): LessonOutcome[] {
-  const filePath = path.resolve(projectRoot, OUTCOMES_JSONL);
-  if (!fs.existsSync(filePath)) return [];
-  const lines = fs.readFileSync(filePath, "utf-8").split("\n");
-  const out: LessonOutcome[] = [];
-  for (const line of lines) {
-    if (!line.trim()) continue;
-    let event: LessonOutcome;
-    try {
-      event = JSON.parse(line) as LessonOutcome;
-    } catch {
-      continue;
-    }
-    if (options.recallId && event.recallId !== options.recallId) continue;
-    if (options.lessonId && event.lessonId !== options.lessonId) continue;
-    out.push(event);
-    if (options.limit !== undefined && out.length >= options.limit) break;
-  }
-  return out;
+  return getOutcomeStore(projectRoot).read({
+    limit: options.limit,
+    filter: (event) => {
+      if (options.recallId && event.recallId !== options.recallId) return false;
+      if (options.lessonId && event.lessonId !== options.lessonId) return false;
+      return true;
+    },
+  });
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/tests/jsonl-store.test.js
+++ b/tests/jsonl-store.test.js
@@ -1,0 +1,465 @@
+/**
+ * Tests for the shared `createJsonlStore` factory (issue #43).
+ *
+ * Coverage:
+ *   - append: id-based idempotency, returns existing record on collision
+ *   - appendWithWindow: window dedupe by (key, timestamp) AND id fallback
+ *   - read: filter / since / limit / runtime validation
+ *   - exists: id lookup, file-missing tolerance
+ *   - validators: runtime rejection of structurally wrong but JSON-valid lines
+ *   - corrupt-line tolerance (mixed valid + invalid lines on disk)
+ *   - lazy mkdir on first append
+ *
+ * The shared store is consumed by `feedback.ts` and `lesson-outcome.ts`;
+ * those modules' own tests verify the typed adapters. This file exercises
+ * the generic factory with a small synthetic record type.
+ *
+ * Executor: Devin
+ */
+
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+  createJsonlStore,
+  isObjectWithId,
+  getString,
+  getOptionalString,
+  isStringEnum,
+} from "../dist/core/jsonl-store.js";
+
+// ─── Synthetic record + schema for the store under test ─────────────
+
+/** @typedef {{ id: string; group: string; value: string; timestamp: string; note?: string }} Rec */
+
+const KINDS = ["a", "b"];
+
+/** @type {import("../dist/core/jsonl-store.js").JsonlSchema<Rec>} */
+const recSchema = {
+  validate(raw) {
+    if (!isObjectWithId(raw)) return null;
+    const group = getString(raw, "group");
+    const value = isStringEnum(raw, "value", KINDS);
+    const timestamp = getString(raw, "timestamp");
+    if (group === null || value === null || timestamp === null) return null;
+    const note = getOptionalString(raw, "note");
+    if (note === null) return null;
+    /** @type {Rec} */
+    const out = { id: raw.id, group, value, timestamp };
+    if (note !== undefined) out.note = note;
+    return out;
+  },
+  idOf: (rec) => rec.id,
+  timestampOf: (rec) => rec.timestamp,
+};
+
+// ─── Test scaffolding ───────────────────────────────────────────────
+
+let tmpDir;
+let storePath;
+
+before(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "jsonl-store-test-"));
+});
+
+after(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  // Fresh path per test so cases don't leak state.
+  storePath = path.join(tmpDir, `s-${Date.now()}-${Math.random()}.jsonl`);
+});
+
+// ─── append() ───────────────────────────────────────────────────────
+
+describe("createJsonlStore — append() id idempotency", () => {
+  it("first append writes; on-disk file contains one line", () => {
+    const store = createJsonlStore(storePath, recSchema);
+    const r1 = store.append({
+      id: "1",
+      group: "g1",
+      value: "a",
+      timestamp: "2025-01-01T00:00:00Z",
+    });
+    assert.equal(r1.written, true);
+    assert.equal(r1.event.id, "1");
+    assert.equal(r1.path, storePath);
+
+    const onDisk = fs.readFileSync(storePath, "utf-8");
+    assert.equal(onDisk.split("\n").filter(Boolean).length, 1);
+  });
+
+  it("re-append with same id is a no-op; returns the existing record", () => {
+    const store = createJsonlStore(storePath, recSchema);
+    const original = {
+      id: "1",
+      group: "g1",
+      value: "a",
+      timestamp: "2025-01-01T00:00:00Z",
+    };
+    store.append(original);
+
+    // Same id but DIFFERENT payload — store should return the *original*,
+    // not silently overwrite.
+    const r2 = store.append({
+      id: "1",
+      group: "DIFFERENT",
+      value: "b",
+      timestamp: "2099-12-31T23:59:59Z",
+    });
+    assert.equal(r2.written, false);
+    assert.deepStrictEqual(r2.event, original);
+
+    const lines = fs.readFileSync(storePath, "utf-8").split("\n").filter(Boolean);
+    assert.equal(lines.length, 1, "no second line written on dedupe");
+  });
+
+  it("different ids both persist", () => {
+    const store = createJsonlStore(storePath, recSchema);
+    store.append({ id: "1", group: "g", value: "a", timestamp: "2025-01-01T00:00:00Z" });
+    store.append({ id: "2", group: "g", value: "a", timestamp: "2025-01-02T00:00:00Z" });
+    assert.equal(store.read().length, 2);
+  });
+
+  it("creates the parent directory lazily on first append", () => {
+    const nested = path.join(tmpDir, "nested-" + Date.now(), "deep", "store.jsonl");
+    assert.equal(fs.existsSync(path.dirname(nested)), false);
+    const store = createJsonlStore(nested, recSchema);
+    store.append({ id: "1", group: "g", value: "a", timestamp: "2025-01-01T00:00:00Z" });
+    assert.equal(fs.existsSync(nested), true);
+  });
+});
+
+// ─── appendWithWindow() ─────────────────────────────────────────────
+
+describe("createJsonlStore — appendWithWindow() time-window dedupe", () => {
+  const windowMs = 60 * 1000; // 1 minute
+
+  it("inside-window same-key collapse: returns windowDeduped=true and does not write", () => {
+    const store = createJsonlStore(storePath, recSchema);
+    const a = {
+      id: "1",
+      group: "shared-key",
+      value: "a",
+      timestamp: "2025-01-01T00:00:00Z",
+    };
+    store.appendWithWindow(a, { windowMs, windowKeyOf: (r) => r.group });
+
+    // 30s later, same group, DIFFERENT id — should still be deduped.
+    const r2 = store.appendWithWindow(
+      {
+        id: "2",
+        group: "shared-key",
+        value: "a",
+        timestamp: "2025-01-01T00:00:30Z",
+      },
+      { windowMs, windowKeyOf: (r) => r.group },
+    );
+    assert.equal(r2.written, false);
+    assert.equal(r2.windowDeduped, true);
+    assert.deepStrictEqual(r2.event, a);
+    assert.equal(store.read().length, 1);
+  });
+
+  it("outside-window same-key writes; both rows persist", () => {
+    const store = createJsonlStore(storePath, recSchema);
+    store.appendWithWindow(
+      { id: "1", group: "k", value: "a", timestamp: "2025-01-01T00:00:00Z" },
+      { windowMs, windowKeyOf: (r) => r.group },
+    );
+    const r2 = store.appendWithWindow(
+      { id: "2", group: "k", value: "a", timestamp: "2025-01-01T00:05:00Z" }, // 5min later
+      { windowMs, windowKeyOf: (r) => r.group },
+    );
+    assert.equal(r2.written, true);
+    assert.equal(store.read().length, 2);
+  });
+
+  it("inside-window different-key writes (the key, not just time, gates dedupe)", () => {
+    const store = createJsonlStore(storePath, recSchema);
+    store.appendWithWindow(
+      { id: "1", group: "k1", value: "a", timestamp: "2025-01-01T00:00:00Z" },
+      { windowMs, windowKeyOf: (r) => r.group },
+    );
+    const r2 = store.appendWithWindow(
+      { id: "2", group: "k2", value: "a", timestamp: "2025-01-01T00:00:30Z" },
+      { windowMs, windowKeyOf: (r) => r.group },
+    );
+    assert.equal(r2.written, true);
+    assert.equal(store.read().length, 2);
+  });
+
+  it("id-equality wins over window: same id returns written=false WITHOUT windowDeduped", () => {
+    const store = createJsonlStore(storePath, recSchema);
+    const original = {
+      id: "1",
+      group: "k",
+      value: "a",
+      timestamp: "2025-01-01T00:00:00Z",
+    };
+    store.appendWithWindow(original, { windowMs, windowKeyOf: (r) => r.group });
+    const r2 = store.appendWithWindow(
+      { id: "1", group: "k", value: "b", timestamp: "2099-01-01T00:00:00Z" },
+      { windowMs, windowKeyOf: (r) => r.group },
+    );
+    assert.equal(r2.written, false);
+    assert.equal(r2.windowDeduped, undefined);
+    assert.deepStrictEqual(r2.event, original);
+  });
+
+  it("throws if schema lacks timestampOf", () => {
+    const noTsSchema = { ...recSchema };
+    delete noTsSchema.timestampOf;
+    const store = createJsonlStore(storePath, noTsSchema);
+    assert.throws(
+      () =>
+        store.appendWithWindow(
+          { id: "1", group: "k", value: "a", timestamp: "2025-01-01T00:00:00Z" },
+          { windowMs, windowKeyOf: (r) => r.group },
+        ),
+      /timestampOf/,
+    );
+  });
+});
+
+// ─── read() ─────────────────────────────────────────────────────────
+
+describe("createJsonlStore — read() with filters", () => {
+  function seed() {
+    const store = createJsonlStore(storePath, recSchema);
+    store.append({ id: "1", group: "g1", value: "a", timestamp: "2025-01-01T00:00:00Z" });
+    store.append({ id: "2", group: "g1", value: "b", timestamp: "2025-01-02T00:00:00Z" });
+    store.append({ id: "3", group: "g2", value: "a", timestamp: "2025-01-03T00:00:00Z" });
+    return store;
+  }
+
+  it("no options returns all valid records in order", () => {
+    const store = seed();
+    const all = store.read();
+    assert.deepStrictEqual(
+      all.map((r) => r.id),
+      ["1", "2", "3"],
+    );
+  });
+
+  it("filter narrows to matching records", () => {
+    const store = seed();
+    const out = store.read({ filter: (r) => r.group === "g1" });
+    assert.deepStrictEqual(
+      out.map((r) => r.id),
+      ["1", "2"],
+    );
+  });
+
+  it("since filters by timestamp inclusive of bound", () => {
+    const store = seed();
+    const out = store.read({ since: "2025-01-02T00:00:00Z" });
+    assert.deepStrictEqual(
+      out.map((r) => r.id),
+      ["2", "3"],
+    );
+  });
+
+  it("limit short-circuits the read", () => {
+    const store = seed();
+    const out = store.read({ limit: 2 });
+    assert.equal(out.length, 2);
+    assert.deepStrictEqual(
+      out.map((r) => r.id),
+      ["1", "2"],
+    );
+  });
+
+  it("missing file returns []", () => {
+    const store = createJsonlStore(storePath, recSchema);
+    assert.deepStrictEqual(store.read(), []);
+  });
+
+  it("read({since}) throws if schema lacks timestampOf", () => {
+    const noTsSchema = { ...recSchema };
+    delete noTsSchema.timestampOf;
+    const store = createJsonlStore(storePath, noTsSchema);
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({ id: "1", group: "g", value: "a", timestamp: "2025-01-01T00:00:00Z" }) + "\n",
+    );
+    assert.throws(() => store.read({ since: "2024-01-01T00:00:00Z" }), /timestampOf/);
+  });
+});
+
+// ─── Runtime validation ─────────────────────────────────────────────
+
+describe("createJsonlStore — runtime validation rejects malformed records", () => {
+  it("missing required field is dropped silently", () => {
+    fs.writeFileSync(
+      storePath,
+      [
+        JSON.stringify({ id: "1", group: "g", value: "a", timestamp: "2025-01-01T00:00:00Z" }),
+        JSON.stringify({ id: "2", group: "g", timestamp: "2025-01-01T00:00:00Z" }), // no value
+        JSON.stringify({ id: "3", group: "g", value: "a", timestamp: "2025-01-01T00:00:00Z" }),
+      ].join("\n") + "\n",
+    );
+    const store = createJsonlStore(storePath, recSchema);
+    const out = store.read();
+    assert.deepStrictEqual(
+      out.map((r) => r.id),
+      ["1", "3"],
+    );
+  });
+
+  it("wrong type for required field is dropped (e.g. value=42 instead of string)", () => {
+    fs.writeFileSync(
+      storePath,
+      [
+        JSON.stringify({ id: "1", group: "g", value: "a", timestamp: "2025-01-01T00:00:00Z" }),
+        JSON.stringify({ id: "2", group: "g", value: 42, timestamp: "2025-01-01T00:00:00Z" }),
+        JSON.stringify({ id: "3", group: "g", value: "b", timestamp: "2025-01-01T00:00:00Z" }),
+      ].join("\n") + "\n",
+    );
+    const out = createJsonlStore(storePath, recSchema).read();
+    assert.deepStrictEqual(
+      out.map((r) => r.id),
+      ["1", "3"],
+    );
+  });
+
+  it("string value not in enum is dropped", () => {
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({ id: "1", group: "g", value: "z", timestamp: "2025-01-01T00:00:00Z" }) + "\n",
+    );
+    assert.deepStrictEqual(createJsonlStore(storePath, recSchema).read(), []);
+  });
+
+  it("missing or non-string id is dropped", () => {
+    fs.writeFileSync(
+      storePath,
+      [
+        JSON.stringify({ group: "g", value: "a", timestamp: "2025-01-01T00:00:00Z" }), // no id
+        JSON.stringify({ id: 42, group: "g", value: "a", timestamp: "2025-01-01T00:00:00Z" }), // numeric id
+        JSON.stringify({ id: "", group: "g", value: "a", timestamp: "2025-01-01T00:00:00Z" }), // empty id
+      ].join("\n") + "\n",
+    );
+    assert.deepStrictEqual(createJsonlStore(storePath, recSchema).read(), []);
+  });
+
+  it("array, null, primitive lines are dropped", () => {
+    fs.writeFileSync(
+      storePath,
+      [JSON.stringify([1, 2, 3]), "null", "42", '"a string"', JSON.stringify({ id: "1", group: "g", value: "a", timestamp: "2025-01-01T00:00:00Z" })].join("\n") +
+        "\n",
+    );
+    const out = createJsonlStore(storePath, recSchema).read();
+    assert.equal(out.length, 1);
+  });
+});
+
+// ─── Corrupt-line tolerance ─────────────────────────────────────────
+
+describe("createJsonlStore — corrupt-line tolerance", () => {
+  it("malformed JSON lines are skipped, valid ones returned", () => {
+    fs.writeFileSync(
+      storePath,
+      [
+        JSON.stringify({ id: "1", group: "g", value: "a", timestamp: "2025-01-01T00:00:00Z" }),
+        "{ not valid json",
+        JSON.stringify({ id: "2", group: "g", value: "a", timestamp: "2025-01-02T00:00:00Z" }),
+        "",
+        "    ",
+        JSON.stringify({ id: "3", group: "g", value: "a", timestamp: "2025-01-03T00:00:00Z" }),
+      ].join("\n") + "\n",
+    );
+    const out = createJsonlStore(storePath, recSchema).read();
+    assert.deepStrictEqual(
+      out.map((r) => r.id),
+      ["1", "2", "3"],
+    );
+  });
+
+  it("a corrupt line does not block append idempotency check", () => {
+    fs.writeFileSync(
+      storePath,
+      [
+        "garbage line",
+        JSON.stringify({ id: "existing", group: "g", value: "a", timestamp: "2025-01-01T00:00:00Z" }),
+      ].join("\n") + "\n",
+    );
+    const store = createJsonlStore(storePath, recSchema);
+    const r = store.append({
+      id: "existing",
+      group: "different",
+      value: "b",
+      timestamp: "2099-01-01T00:00:00Z",
+    });
+    assert.equal(r.written, false);
+    assert.equal(r.event.group, "g");
+  });
+});
+
+// ─── exists() ───────────────────────────────────────────────────────
+
+describe("createJsonlStore — exists()", () => {
+  it("returns false when the file does not exist", () => {
+    const store = createJsonlStore(storePath, recSchema);
+    assert.equal(store.exists("anything"), false);
+  });
+
+  it("returns true after a record with that id is appended", () => {
+    const store = createJsonlStore(storePath, recSchema);
+    store.append({ id: "1", group: "g", value: "a", timestamp: "2025-01-01T00:00:00Z" });
+    assert.equal(store.exists("1"), true);
+    assert.equal(store.exists("nope"), false);
+  });
+
+  it("ignores malformed lines when checking existence", () => {
+    fs.writeFileSync(
+      storePath,
+      [
+        "garbage",
+        JSON.stringify({ id: "real", group: "g", value: "a", timestamp: "2025-01-01T00:00:00Z" }),
+      ].join("\n") + "\n",
+    );
+    const store = createJsonlStore(storePath, recSchema);
+    assert.equal(store.exists("real"), true);
+    assert.equal(store.exists("garbage"), false);
+  });
+});
+
+// ─── Validator helpers ──────────────────────────────────────────────
+
+describe("createJsonlStore — exported validator helpers", () => {
+  it("isObjectWithId rejects non-objects, arrays, and missing/empty/non-string ids", () => {
+    assert.equal(isObjectWithId(null), false);
+    assert.equal(isObjectWithId(undefined), false);
+    assert.equal(isObjectWithId("string"), false);
+    assert.equal(isObjectWithId(42), false);
+    assert.equal(isObjectWithId([1, 2]), false);
+    assert.equal(isObjectWithId({}), false);
+    assert.equal(isObjectWithId({ id: 1 }), false);
+    assert.equal(isObjectWithId({ id: "" }), false);
+    assert.equal(isObjectWithId({ id: "ok" }), true);
+  });
+
+  it("getString returns the string or null", () => {
+    assert.equal(getString({ a: "x" }, "a"), "x");
+    assert.equal(getString({ a: 1 }, "a"), null);
+    assert.equal(getString({}, "a"), null);
+  });
+
+  it("getOptionalString distinguishes absent (undefined) from wrong-type (null)", () => {
+    assert.equal(getOptionalString({}, "a"), undefined);
+    assert.equal(getOptionalString({ a: undefined }, "a"), undefined);
+    assert.equal(getOptionalString({ a: "x" }, "a"), "x");
+    assert.equal(getOptionalString({ a: 1 }, "a"), null);
+  });
+
+  it("isStringEnum returns the narrowed value or null", () => {
+    assert.equal(isStringEnum({ k: "a" }, "k", ["a", "b"]), "a");
+    assert.equal(isStringEnum({ k: "z" }, "k", ["a", "b"]), null);
+    assert.equal(isStringEnum({ k: 42 }, "k", ["a", "b"]), null);
+  });
+});


### PR DESCRIPTION
## Description

Closes #43 — Antigravity flagged on PR #32 that `feedback.ts` and `lesson-outcome.ts` duplicated ~300 LOC of append-only JSONL plumbing AND that the readers trusted `JSON.parse` output via `as T` casts (no runtime validation). This PR extracts the shared primitives into `src/core/jsonl-store.ts` and adds field-by-field validators that drop structurally invalid lines, matching the strict pattern `hint-state.ts` already uses.

Fixes #43

### What ships

| File | Role |
|:---|:---|
| `src/core/jsonl-store.ts` (**new**) | `JsonlSchema<T>` (`validate(unknown) → T \| null` + `idOf` + `timestampOf`) and `JsonlStore<T>` (`append` / `appendWithWindow` / `read` / `exists`). Plus shared validator helpers (`isObjectWithId`, `getString`, `getOptionalString`, `isStringEnum`). |
| `src/core/feedback.ts` | Defines `feedbackSchema`. `appendFeedback` / `readFeedback` delegate to the store. External signatures unchanged (pinned by `tests/contract/*` from #35 / PR #63). |
| `src/core/lesson-outcome.ts` | Defines `recallSchema` + `outcomeSchema`. `appendRecall` now uses `appendWithWindow` (`RECALL_DEDUPE_WINDOW_MS`). `appendOutcome` / `readRecalls` / `readOutcomes` delegate to the store. External signatures unchanged. |
| `tests/jsonl-store.test.js` (**new**, 29 tests) | Covers id-idempotency, window dedupe (inside/outside window, key collision, id-wins precedence), read filters (`filter` / `since` / `limit` / missing-file tolerance), runtime validation (missing field, wrong type, enum out-of-range, non-string id, array/null/primitive lines), corrupt-line tolerance, `exists()`, and all four validator helpers. |

### Acceptance criteria (from #43)

- [x] **No behavioral change observable from outside.** External signatures preserved verbatim. The 27 public-API contract tests added in PR #63 (issue #35) pin those signatures and remain green on this branch.
- [ ] **LOC count for the three files strictly decreases.**
  - Current main: `feedback.ts` 501 + `lesson-outcome.ts` 624 = **1125**.
  - This PR: `feedback.ts` 525 + `lesson-outcome.ts` 637 + `jsonl-store.ts` 191 = **1353**.
  - **LOC went UP by 228, NOT down.** Reporting honestly rather than gaming the metric. The issue body's "kills 300 LOC duplication AND adds runtime validation for free" was optimistic: runtime validation is genuinely new code (per AC #3), and three typed schemas (`feedback` / `recall` / `outcome`) cost ~25 LOC each. The trade-off is single-source-of-I/O-truth + runtime validation + dedupe contract pinned in one place — I judge that real value outweighs the line count delta. Happy to back this out or pivot if you disagree, but I don't think there's a way to satisfy AC #3 (runtime validation) while reducing total LOC without sacrificing per-field strictness.
- [x] **Runtime validation rejects malformed lines instead of casting to `T`.** Every read path now goes through `schema.validate()` which narrows `unknown` → `T` field by field. Lines that fail validation are silently dropped (same tolerance as the original `JSON.parse`–`catch` blocks, plus the structural rejection that was previously absent — e.g. a JSON-valid line with `value: 42` instead of `value: "a"` now fails to validate and is excluded, where before it would have been cast to `T` and surfaced to callers).
- [x] **CHANGELOG entry under `[Unreleased] / Refactor`.** See `CHANGELOG.md` lines 56–57.

### Implementation notes (skill discipline)

[`skill-impact-predictor`](.agents/skills/skill-impact-predictor/SKILL.md) was self-applied before any source edit:

- **G1** Working tree clean before edit.
- **G2** Direct targets: 3 source files (1 new, 2 refactored), 1 new test file, 1 CHANGELOG entry. Cited from a `wc -l` baseline + `grep -n` audit of the duplicated patterns.
- **G3** Public API surface unchanged. Every exported function in `feedback.ts` / `lesson-outcome.ts` keeps its name, parameter types, and return shape. The store factory is itself a new exported symbol but lives in `src/core/` (not re-exported from `src/index.ts` or any subpath in `package.json#exports`), so it is **internal**, not public API.
- **G4** Blast radius: 5 files; ~228 net lines added; no breaking changes; full suite 421/421 pass after the change.
- **G5** Scope strictly matches issue #43 acceptance criteria (with the LOC AC explicitly flagged as not met — see above).

Per [`skill-surgical-refactorer`](.agents/skills/skill-surgical-refactorer/SKILL.md): the refactor is isomorphic at the public-API boundary. The 27 contract tests from PR #63 (issue #35) provide the behavioural pin — if any of them broke, the refactor would have leaked outward. They didn't.

### Note: relationship with PR #64 (issue #44, `execFileSync` standardisation)

PR #64 and this PR both touch `src/core/feedback.ts` and `src/core/lesson-outcome.ts`, but in different regions:

- **PR #64** modifies `readGitLog` / `readGitDiffs` (the `execSync` → `execFileSync` swap).
- **This PR** modifies the JSONL append/read paths.

Both branches were created from `main` before the other landed. When PR #64 merges first, this PR will need a trivial rebase that's mostly auto-resolvable since the two diffs target different functions in each file. Happy to do that rebase whenever you merge #64.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking)
- [ ] ✨ New feature (non-breaking)
- [ ] 🛡️ New guard
- [ ] 💥 Breaking change
- [ ] 📝 Documentation only
- [x] 🔧 Refactor (no behavior change)

## Checklist

- [x] My code follows the [consistency rules](.agents/rules/rule-consistency.md)
- [x] I used conventional commit format for the PR title
- [x] I added tests for new functionality (29 tests for the shared store)
- [x] All existing tests pass (`npm test`) — 421/421 (392 pre + 29 new)
- [x] I updated documentation (CHANGELOG `[Unreleased] / Refactor`)
- [x] New guards implement the `Guard` interface from `core/types.ts` — N/A
- [x] No `any` types used
- [x] No new external dependencies added

## For New Guards Only

N/A — refactor PR, no guard added.

## Evidence

`[CODE]` LOC accounting:

```
$ wc -l src/core/{feedback.ts,lesson-outcome.ts,jsonl-store.ts}
   525 src/core/feedback.ts
   637 src/core/lesson-outcome.ts
   191 src/core/jsonl-store.ts
  1353 total

$ git show main:src/core/feedback.ts       | wc -l
501
$ git show main:src/core/lesson-outcome.ts | wc -l
624
# baseline = 1125; delta = +228
```

`[RUNTIME]` Local verification:

```
$ npm run lint
> tsc --noEmit
(clean)

$ npm run build
> tsc && chmod +x dist/cli/index.js
(clean)

$ node --test tests/jsonl-store.test.js
…
ℹ tests 29
ℹ pass 29
ℹ fail 0

$ npm test
…
ℹ tests 421
ℹ pass 421
ℹ fail 0
```

`[CODE]` SemVer class: **Patch** per [`docs/SEMVER.md` §4](https://github.com/tamld/defense-in-depth/blob/main/docs/SEMVER.md) — internal refactor, no public API surface movement, no behaviour change at the module boundary.

Refs PR #32 (Antigravity findings origin), PR #63 (#35 contract tests that pin the external signatures this PR preserves), PR #64 (issue #44, parallel refactor on the same files — non-overlapping regions).

Executor: Devin

Link to Devin session: https://app.devin.ai/sessions/8db2c99daa344211a783529bd088be68
Requested by: @tamld
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tamld/defense-in-depth/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
